### PR TITLE
Allow working in paths that contain @

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -249,7 +249,7 @@ parse_filename(char *str, char *name, int chars_remaining)
 	 * Check if the filename buffer is out of space, preserving one
 	 * character to null terminate the string.
 	 */
-	while (isalnum(*str) || strchr("\\/~_-+:.", *str)) {
+	while (isalnum(*str) || strchr("\\/~_-+:.@", *str)) {
 
 		chars_remaining--;
 


### PR DESCRIPTION
Using cbootimage on a full path containing the "@" character didn't work