### PR TITLE
Use C99 uintXX_t instead of implementation-specific u_intXX_t types

### DIFF
--- a/src/aes_ref.c
+++ b/src/aes_ref.c
@@ -46,11 +46,11 @@ REDISTRIBUTION OF THIS SOFTWARE.
 
 #include "nvaes_ref.h"
 
-static void shift_rows(u_int8_t *state);
-static void mix_sub_columns(u_int8_t *state);
-static void add_round_key(u_int32_t *state, u_int32_t *key);
+static void shift_rows(uint8_t *state);
+static void mix_sub_columns(uint8_t *state);
+static void add_round_key(uint32_t *state, uint32_t *key);
 
-static u_int8_t s_Sbox[256] =
+static uint8_t s_Sbox[256] =
 {	/* forward s-box */
 	0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5,
 	0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
@@ -87,7 +87,7 @@ static u_int8_t s_Sbox[256] =
 };
 
 /* combined Xtimes2[Sbox[]] */
-static u_int8_t s_Xtime2Sbox[256] =
+static uint8_t s_Xtime2Sbox[256] =
 {
 	0xc6, 0xf8, 0xee, 0xf6, 0xff, 0xd6, 0xde, 0x91,
 	0x60, 0x02, 0xce, 0x56, 0xe7, 0xb5, 0x4d, 0xec,
@@ -124,7 +124,7 @@ static u_int8_t s_Xtime2Sbox[256] =
 };
 
 /* combined Xtimes3[Sbox[]] */
-static u_int8_t s_Xtime3Sbox[256] =
+static uint8_t s_Xtime3Sbox[256] =
 {
 	0xa5, 0x84, 0x99, 0x8d, 0x0d, 0xbd, 0xb1, 0x54,
 	0x50, 0x03, 0xa9, 0x7d, 0x19, 0x62, 0xe6, 0x9a,
@@ -165,9 +165,9 @@ static u_int8_t s_Xtime3Sbox[256] =
  * row2 - shifted left 2 and row3 - shifted left 3
  */
 static void
-shift_rows(u_int8_t *state)
+shift_rows(uint8_t *state)
 {
-	u_int8_t tmp;
+	uint8_t tmp;
 
 	/* just substitute row 0 */
 	state[ 0] = s_Sbox[state[ 0]];
@@ -200,9 +200,9 @@ shift_rows(u_int8_t *state)
 
 /* recombine and mix each row in a column */
 static void
-mix_sub_columns(u_int8_t *state)
+mix_sub_columns(uint8_t *state)
 {
-	u_int8_t tmp[4 * NVAES_STATECOLS];
+	uint8_t tmp[4 * NVAES_STATECOLS];
 
 	/* mixing column 0 */
 	tmp[ 0] = s_Xtime2Sbox[state[ 0]] ^ s_Xtime3Sbox[state[ 5]] ^
@@ -253,7 +253,7 @@ mix_sub_columns(u_int8_t *state)
  */
 
 static void
-add_round_key(u_int32_t *state, u_int32_t *key)
+add_round_key(uint32_t *state, uint32_t *key)
 {
 	int idx;
 
@@ -261,17 +261,17 @@ add_round_key(u_int32_t *state, u_int32_t *key)
 		state[idx] ^= key[idx];
 }
 
-static u_int8_t s_Rcon[11] =
+static uint8_t s_Rcon[11] =
 {
 	0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36
 };
 
 /* produce NVAES_STATECOLS bytes for each round */
 void
-nv_aes_expand_key(u_int8_t *key, u_int8_t *expkey)
+nv_aes_expand_key(uint8_t *key, uint8_t *expkey)
 {
-	u_int8_t  tmp0, tmp1, tmp2, tmp3, tmp4;
-	u_int32_t idx;
+	uint8_t  tmp0, tmp1, tmp2, tmp3, tmp4;
+	uint32_t idx;
 
 	memcpy(expkey, key, NVAES_KEYCOLS * 4);
 
@@ -304,13 +304,13 @@ nv_aes_expand_key(u_int8_t *key, u_int8_t *expkey)
 
 /* encrypt one 128 bit block */
 void
-nv_aes_encrypt(u_int8_t *in, u_int8_t *expkey, u_int8_t *out)
+nv_aes_encrypt(uint8_t *in, uint8_t *expkey, uint8_t *out)
 {
-	u_int8_t  state[NVAES_STATECOLS * 4];
-	u_int32_t round;
+	uint8_t  state[NVAES_STATECOLS * 4];
+	uint32_t round;
 
 	memcpy(state, in, NVAES_STATECOLS * 4);
-	add_round_key((u_int32_t *)state, (u_int32_t *)expkey);
+	add_round_key((uint32_t *)state, (uint32_t *)expkey);
 
 	for (round = 1; round < NVAES_ROUNDS + 1; round++) {
 		if (round < NVAES_ROUNDS)
@@ -318,7 +318,7 @@ nv_aes_encrypt(u_int8_t *in, u_int8_t *expkey, u_int8_t *out)
 		else
 			shift_rows (state);
 
-		add_round_key((u_int32_t *)state, (u_int32_t *)expkey +
+		add_round_key((uint32_t *)state, (uint32_t *)expkey +
 					round * NVAES_STATECOLS);
 	}
 

--- a/src/bct_dump.c
+++ b/src/bct_dump.c
@@ -43,9 +43,9 @@ typedef struct {
 
 #define PARAM_TYPE_BINARY_DATA_MAX_SIZE 256
 typedef union {
-	u_int32_t val;
-	u_int8_t uid[16];
-	u_int8_t binary[PARAM_TYPE_BINARY_DATA_MAX_SIZE];
+	uint32_t val;
+	uint8_t uid[16];
+	uint8_t binary[PARAM_TYPE_BINARY_DATA_MAX_SIZE];
 } param_types;
 
 #define MAX_PARAM_SIZE sizeof(param_types)
@@ -96,17 +96,17 @@ static value_data const mts_values[] = {
 /*****************************************************************************/
 static void format_u32_hex8(parse_token id, char const * message, void * data)
 {
-	printf("%s0x%08x;\n", message, *((u_int32_t *) data));
+	printf("%s0x%08x;\n", message, *((uint32_t *) data));
 }
 
 static void format_u32(parse_token id, char const * message, void * data)
 {
-	printf("%s%d;\n", message, *((u_int32_t *) data));
+	printf("%s%d;\n", message, *((uint32_t *) data));
 }
 
 static void format_chipuid(parse_token id, char const * message, void * data)
 {
-	u_int8_t *uid = (u_int8_t *)data;
+	uint8_t *uid = (uint8_t *)data;
 	int byte_index;
 	char uid_str[35] = "0x";
 	char *s = &uid_str[2];
@@ -119,7 +119,7 @@ static void format_chipuid(parse_token id, char const * message, void * data)
 
 static void format_hex_16_bytes(parse_token id, char const * message, void * data)
 {
-	u_int8_t *p_byte = (u_int8_t *)data;
+	uint8_t *p_byte = (uint8_t *)data;
 	int byte_index;
 
 	printf("%s", message);
@@ -132,7 +132,7 @@ static void format_hex_16_bytes(parse_token id, char const * message, void * dat
 static void format_rsa_param(parse_token id, char const * message, void * data)
 {
 #define MAX_BYTE_NUMBER_PER_LINE	16
-	u_int8_t *rsa = (u_int8_t *)data;
+	uint8_t *rsa = (uint8_t *)data;
 	int size, byte_index;
 
 	printf("%s", message);
@@ -177,7 +177,7 @@ static int max_width(field_item const * table)
 /*****************************************************************************/
 static enum_item const * find_enum_item(build_image_context *context,
 					enum_item const * table,
-					u_int32_t value)
+					uint32_t value)
 {
 	int i;
 
@@ -191,7 +191,7 @@ static enum_item const * find_enum_item(build_image_context *context,
 /*****************************************************************************/
 static void display_enum_value(build_image_context *context,
 			       enum_item const * table,
-			       u_int32_t value)
+			       uint32_t value)
 {
 	enum_item const * e_item = find_enum_item(context, table, value);
 
@@ -203,7 +203,7 @@ static void display_enum_value(build_image_context *context,
 /*****************************************************************************/
 static int display_field_value(build_image_context *context,
 			       field_item const * item,
-			       u_int32_t value)
+			       uint32_t value)
 {
 	switch (item->type) {
 		case field_type_enum:
@@ -230,10 +230,10 @@ int main(int argc, char *argv[])
 {
 	int e;
 	build_image_context context;
-	u_int32_t bootloaders_used;
-	u_int32_t parameters_used;
-	u_int32_t sdram_used;
-	u_int32_t mts_used;
+	uint32_t bootloaders_used;
+	uint32_t parameters_used;
+	uint32_t sdram_used;
+	uint32_t mts_used;
 	nvboot_dev_type type;
 	param_types data;
 	int i;

--- a/src/cbootimage.c
+++ b/src/cbootimage.c
@@ -227,8 +227,8 @@ main(int argc, char *argv[])
 
 	/* Read the bct data from image if bct configs needs to be updated */
 	if (context.update_image) {
-		u_int32_t offset = 0, bct_size, actual_size;
-		u_int8_t *data_block;
+		uint32_t offset = 0, bct_size, actual_size;
+		uint8_t *data_block;
 		struct stat stats;
 
 		if (stat(context.input_image_filename, &stats) != 0) {

--- a/src/cbootimage.h
+++ b/src/cbootimage.h
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <math.h>
+#include <stdint.h>
 
 #define NVBOOT_AES_BLOCK_SIZE_LOG2 4
 #define MAX_BUFFER 200
@@ -86,49 +87,49 @@ typedef struct build_image_context_rec
 	char *output_image_filename;
 	char *input_image_filename;
 	FILE *raw_file;
-	u_int32_t block_size;
-	u_int32_t block_size_log2;
-	u_int32_t page_size;
-	u_int32_t page_size_log2;
-	u_int32_t pages_per_blk;
-	u_int32_t partition_size;
-	u_int32_t redundancy;
-	u_int32_t version;
-	u_int32_t bct_copy;
+	uint32_t block_size;
+	uint32_t block_size_log2;
+	uint32_t page_size;
+	uint32_t page_size_log2;
+	uint32_t pages_per_blk;
+	uint32_t partition_size;
+	uint32_t redundancy;
+	uint32_t version;
+	uint32_t bct_copy;
 	/*
 	 * Number of blocks at start of device to skip before the BCT.
 	 * This may be used to reserve space for a partition table, for
 	 * example, in order to write the resultant boot image to e.g. an
 	 * SD card while using the remaining space for a user filesystem.
 	 */
-	u_int32_t pre_bct_pad_blocks;
+	uint32_t pre_bct_pad_blocks;
 	/* Allocation data. */
 	struct blk_data_rec *memory; /* Representation of memory */
 	/* block number for the BCT block */
-	u_int32_t next_bct_blk;
+	uint32_t next_bct_blk;
 
 	char *newbl_filename;
-	u_int32_t newbl_load_addr;
-	u_int32_t newbl_entry_point;
-	u_int32_t newbl_attr;
-	u_int8_t generate_bct;
-	u_int8_t *bct;
+	uint32_t newbl_load_addr;
+	uint32_t newbl_entry_point;
+	uint32_t newbl_attr;
+	uint8_t generate_bct;
+	uint8_t *bct;
 
 	char *mts_filename;
-	u_int32_t mts_load_addr;
-	u_int32_t mts_entry_point;
-	u_int32_t mts_attr;
+	uint32_t mts_load_addr;
+	uint32_t mts_entry_point;
+	uint32_t mts_attr;
 
 	char *bct_filename;
-	u_int32_t last_blk;
-	u_int32_t bct_size; /* The BCT file size */
-	u_int32_t boot_data_version; /* The boot data version of BCT */
-	u_int8_t bct_init; /* The flag for the memory allocation of bct */
-	u_int32_t odm_data; /* The odm data value */
-	u_int8_t unique_chip_id[16]; /* The unique chip uid */
-	u_int8_t secure_jtag_control; /* The flag for enabling jtag control */
-	u_int32_t secure_debug_control; /* The flag for enabling jtag control */
-	u_int8_t update_image; /* The flag for updating image */
+	uint32_t last_blk;
+	uint32_t bct_size; /* The BCT file size */
+	uint32_t boot_data_version; /* The boot data version of BCT */
+	uint8_t bct_init; /* The flag for the memory allocation of bct */
+	uint32_t odm_data; /* The odm data value */
+	uint8_t unique_chip_id[16]; /* The unique chip uid */
+	uint8_t secure_jtag_control; /* The flag for enabling jtag control */
+	uint32_t secure_debug_control; /* The flag for enabling jtag control */
+	uint8_t update_image; /* The flag for updating image */
 } build_image_context;
 
 /* Function prototypes */

--- a/src/context.c
+++ b/src/context.c
@@ -31,7 +31,7 @@ cleanup_context(build_image_context *context)
 int
 init_context(build_image_context *context)
 {
-	u_int32_t value;
+	uint32_t value;
 
 	/* Set defaults */
 	context->memory = new_block_list();

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -27,35 +27,35 @@
 
 /* Local function declarations */
 static void
-apply_cbc_chain_data(u_int8_t *cbc_chain_data,
-			u_int8_t *src,
-			u_int8_t *dst);
+apply_cbc_chain_data(uint8_t *cbc_chain_data,
+			uint8_t *src,
+			uint8_t *dst);
 
 static void
-generate_key_schedule(u_int8_t *key, u_int8_t *key_schedule);
+generate_key_schedule(uint8_t *key, uint8_t *key_schedule);
 
 static void
-encrypt_object( u_int8_t	*key_schedule,
-		u_int8_t	*src,
-		u_int8_t	*dst,
-		u_int32_t	num_aes_blocks);
+encrypt_object( uint8_t	*key_schedule,
+		uint8_t	*src,
+		uint8_t	*dst,
+		uint32_t	num_aes_blocks);
 
 static int
-encrypt_and_sign(u_int8_t		*key,
-		 u_int8_t		*src,
-		 u_int32_t		length,
-		 u_int8_t		*sig_dst);
+encrypt_and_sign(uint8_t		*key,
+		 uint8_t		*src,
+		 uint32_t		length,
+		 uint8_t		*sig_dst);
 
-u_int8_t enable_debug_crypto = 0;
+uint8_t enable_debug_crypto = 0;
 
 /* Implementation */
-static u_int8_t zero_key[16] = { 0, 0, 0, 0, 0, 0, 0, 0,
+static uint8_t zero_key[16] = { 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0 };
 
 static void
-print_vector(char *name, u_int32_t num_bytes, u_int8_t *data)
+print_vector(char *name, uint32_t num_bytes, uint8_t *data)
 {
-	u_int32_t i;
+	uint32_t i;
 
 	printf("%s [%d] @%p", name, num_bytes, data);
 	for (i=0; i<num_bytes; i++) {
@@ -70,9 +70,9 @@ print_vector(char *name, u_int32_t num_bytes, u_int8_t *data)
 
 
 static void
-apply_cbc_chain_data(u_int8_t *cbc_chain_data,
-			u_int8_t *src,
-			u_int8_t *dst)
+apply_cbc_chain_data(uint8_t *cbc_chain_data,
+			uint8_t *src,
+			uint8_t *dst)
 {
 	int i;
 
@@ -82,7 +82,7 @@ apply_cbc_chain_data(u_int8_t *cbc_chain_data,
 }
 
 static void
-generate_key_schedule(u_int8_t *key, u_int8_t *key_schedule)
+generate_key_schedule(uint8_t *key, uint8_t *key_schedule)
 {
 	/*
 	 * The only need for a key is for signing/checksum purposes, so
@@ -92,14 +92,14 @@ generate_key_schedule(u_int8_t *key, u_int8_t *key_schedule)
 }
 
 static void
-encrypt_object(u_int8_t	*key_schedule,
-		u_int8_t	*src,
-		u_int8_t	*dst,
-		u_int32_t	num_aes_blocks)
+encrypt_object(uint8_t	*key_schedule,
+		uint8_t	*src,
+		uint8_t	*dst,
+		uint32_t	num_aes_blocks)
 {
-	u_int32_t i;
-	u_int8_t *cbc_chain_data;
-	u_int8_t  tmp_data[KEY_LENGTH];
+	uint32_t i;
+	uint8_t *cbc_chain_data;
+	uint8_t  tmp_data[KEY_LENGTH];
 
 	cbc_chain_data = zero_key; /* Convenient array of 0's for IV */
 
@@ -130,15 +130,15 @@ encrypt_object(u_int8_t	*key_schedule,
 }
 
 static void
-left_shift_vector(u_int8_t *in,
-		  u_int8_t	*out,
-		  u_int32_t size)
+left_shift_vector(uint8_t *in,
+		  uint8_t	*out,
+		  uint32_t size)
 {
-	u_int32_t i;
-	u_int8_t carry = 0;
+	uint32_t i;
+	uint8_t carry = 0;
 
 	for (i=0; i<size; i++) {
-		u_int32_t j = size-1-i;
+		uint32_t j = size-1-i;
 
 		out[j] = (in[j] << 1) | carry;
 		carry = in[j] >> 7; /* get most significant bit */
@@ -147,18 +147,18 @@ left_shift_vector(u_int8_t *in,
 
 static void
 sign_objext(
-	u_int8_t	*key,
-	u_int8_t	*key_schedule,
-	u_int8_t	*src,
-	u_int8_t	*dst,
-	u_int32_t	num_aes_blocks)
+	uint8_t	*key,
+	uint8_t	*key_schedule,
+	uint8_t	*src,
+	uint8_t	*dst,
+	uint32_t	num_aes_blocks)
 {
-	u_int32_t i;
-	u_int8_t *cbc_chain_data;
+	uint32_t i;
+	uint8_t *cbc_chain_data;
 
-	u_int8_t	l[KEY_LENGTH];
-	u_int8_t	k1[KEY_LENGTH];
-	u_int8_t	tmp_data[KEY_LENGTH];
+	uint8_t	l[KEY_LENGTH];
+	uint8_t	k1[KEY_LENGTH];
+	uint8_t	tmp_data[KEY_LENGTH];
 
 	cbc_chain_data = zero_key; /* Convenient array of 0's for IV */
 
@@ -193,7 +193,7 @@ sign_objext(
 			apply_cbc_chain_data(tmp_data, k1, tmp_data);
 
 		/* encrypt the AES block */
-		nv_aes_encrypt(tmp_data, key_schedule, (u_int8_t*)dst);
+		nv_aes_encrypt(tmp_data, key_schedule, (uint8_t*)dst);
 
 		if (enable_debug_crypto) {
 			printf("sign_objext: block %d of %d\n", i,
@@ -202,26 +202,26 @@ sign_objext(
 			print_vector("AES-CMAC Xor", KEY_LENGTH, tmp_data);
 			print_vector("AES-CMAC Dst",
 				KEY_LENGTH,
-				(u_int8_t*)dst);
+				(uint8_t*)dst);
 		}
 
 		/* Update pointers for next loop. */
-		cbc_chain_data = (u_int8_t*)dst;
+		cbc_chain_data = (uint8_t*)dst;
 		src += KEY_LENGTH;
 	}
 
 	if (enable_debug_crypto)
-		print_vector("AES-CMAC Hash", KEY_LENGTH, (u_int8_t*)dst);
+		print_vector("AES-CMAC Hash", KEY_LENGTH, (uint8_t*)dst);
 }
 
 static int
-encrypt_and_sign(u_int8_t		*key,
-		u_int8_t		*src,
-		u_int32_t		length,
-		u_int8_t		*sig_dst)
+encrypt_and_sign(uint8_t		*key,
+		uint8_t		*src,
+		uint32_t		length,
+		uint8_t		*sig_dst)
 {
-	u_int32_t	num_aes_blocks;
-	u_int8_t	key_schedule[4*NVAES_STATECOLS*(NVAES_ROUNDS+1)];
+	uint32_t	num_aes_blocks;
+	uint8_t	key_schedule[4*NVAES_STATECOLS*(NVAES_ROUNDS+1)];
 
 	if (enable_debug_crypto) {
 		printf("encrypt_and_sign: length = %d\n", length);
@@ -245,9 +245,9 @@ encrypt_and_sign(u_int8_t		*key,
 }
 
 int
-sign_data_block(u_int8_t *source,
-		u_int32_t length,
-		u_int8_t *signature)
+sign_data_block(uint8_t *source,
+		uint32_t length,
+		uint8_t *signature)
 {
 	return encrypt_and_sign(zero_key,
 				source,
@@ -257,12 +257,12 @@ sign_data_block(u_int8_t *source,
 
 int
 sign_bct(build_image_context *context,
-		u_int8_t *bct)
+		uint8_t *bct)
 {
-	u_int32_t Offset;
-	u_int32_t length;
-	u_int32_t hash_size;
-	u_int8_t *hash_buffer = NULL;
+	uint32_t Offset;
+	uint32_t length;
+	uint32_t hash_size;
+	uint8_t *hash_buffer = NULL;
 	int e = 0;
 
 	assert(bct != NULL);
@@ -307,12 +307,12 @@ sign_bct(build_image_context *context,
  */
 void
 reverse_byte_order(
-	u_int8_t *out,
-	const u_int8_t *in,
-	const u_int32_t size)
+	uint8_t *out,
+	const uint8_t *in,
+	const uint32_t size)
 {
-	u_int32_t i, j;
-	u_int8_t b1, b2;
+	uint32_t i, j;
+	uint8_t b1, b2;
 
 	for (i = 0; i < size / 2; i++) {
 		j = size - 1 - i;
@@ -329,13 +329,13 @@ reverse_byte_order(
 
 int
 sign_bl(build_image_context *context,
-	u_int8_t *bootloader,
-	u_int32_t length,
-	u_int32_t image_instance)
+	uint8_t *bootloader,
+	uint32_t length,
+	uint32_t image_instance)
 {
 	int e = 0;
-	u_int8_t  *hash_buffer;
-	u_int32_t  hash_size;
+	uint8_t  *hash_buffer;
+	uint32_t  hash_size;
 
 	g_soc_config->get_value(token_hash_size,
 			&hash_size, context->bct);
@@ -352,7 +352,7 @@ sign_bl(build_image_context *context,
 
 	if ((e = g_soc_config->setbl_param(image_instance,
 				token_bl_crypto_hash,
-				(u_int32_t*)hash_buffer,
+				(uint32_t*)hash_buffer,
 				context->bct)) != 0)
 		goto fail;
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -37,23 +37,23 @@
 
 int
 sign_bct(build_image_context *context,
-                  u_int8_t *bct);
+                  uint8_t *bct);
 
 int
-sign_data_block(u_int8_t *source,
-		u_int32_t length,
-		u_int8_t *signature);
+sign_data_block(uint8_t *source,
+		uint32_t length,
+		uint8_t *signature);
 
 void
 reverse_byte_order(
-	u_int8_t *out,
-	const u_int8_t *in,
-	const u_int32_t size);
+	uint8_t *out,
+	const uint8_t *in,
+	const uint32_t size);
 
 int
 sign_bl(build_image_context *context,
-	u_int8_t *bootloader,
-	u_int32_t length,
-	u_int32_t image_instance);
+	uint8_t *bootloader,
+	uint32_t length,
+	uint32_t image_instance);
 
 #endif /* #ifndef INCLUDED_CRYPTO_H */

--- a/src/data_layout.c
+++ b/src/data_layout.c
@@ -32,9 +32,9 @@
 
 typedef struct blk_data_rec
 {
-	u_int32_t blk_number;
-	u_int32_t pages_used; /* pages always used starting from 0. */
-	u_int8_t *data;
+	uint32_t blk_number;
+	uint32_t pages_used; /* pages always used starting from 0. */
+	uint8_t *data;
 
 	/* Pointer to ECC errors? */
 
@@ -43,54 +43,54 @@ typedef struct blk_data_rec
 
 /* Function prototypes */
 static block_data
-*new_block(u_int32_t blk_number, u_int32_t block_size);
+*new_block(uint32_t blk_number, uint32_t block_size);
 static block_data
-*find_block(u_int32_t blk_number, block_data  *block_list);
+*find_block(uint32_t blk_number, block_data  *block_list);
 static block_data
-*add_block(u_int32_t blk_number, block_data **block_list,
-			u_int32_t block_size);
+*add_block(uint32_t blk_number, block_data **block_list,
+			uint32_t block_size);
 static int
-erase_block(build_image_context *context, u_int32_t blk_number);
+erase_block(build_image_context *context, uint32_t blk_number);
 
 static int
 write_page(build_image_context *context,
-			u_int32_t blk_number,
-			u_int32_t page_number,
-			u_int8_t *data);
+			uint32_t blk_number,
+			uint32_t page_number,
+			uint8_t *data);
 
 static void
-insert_padding(u_int8_t *data, u_int32_t length);
+insert_padding(uint8_t *data, uint32_t length);
 
 static void
-write_padding(u_int8_t *data, u_int32_t length);
+write_padding(uint8_t *data, uint32_t length);
 
 static int write_bct(build_image_context *context,
-		u_int32_t block,
-		u_int32_t bct_slot);
+		uint32_t block,
+		uint32_t bct_slot);
 
 static void
 set_bl_data(build_image_context *context,
-			u_int32_t instance,
-			u_int32_t start_blk,
-			u_int32_t start_page,
-			u_int32_t length);
+			uint32_t instance,
+			uint32_t start_blk,
+			uint32_t start_page,
+			uint32_t length);
 
 static int write_image(build_image_context *context, file_type image_type);
 
 static void find_new_bct_blk(build_image_context *context);
 static int finish_update(build_image_context *context);
 
-u_int32_t
-iceil_log2(u_int32_t a, u_int32_t b)
+uint32_t
+iceil_log2(uint32_t a, uint32_t b)
 {
 	return (a + (1 << b) - 1) >> b;
 }
 
 /* Returns the smallest power of 2 >= a */
-u_int32_t
-ceil_log2(u_int32_t a)
+uint32_t
+ceil_log2(uint32_t a)
 {
-	u_int32_t result;
+	uint32_t result;
 
 	result = log2(a);
 	if ((1UL << result) < a)
@@ -99,7 +99,7 @@ ceil_log2(u_int32_t a)
 	return result;
 }
 
-static block_data *new_block(u_int32_t blk_number, u_int32_t block_size)
+static block_data *new_block(uint32_t blk_number, uint32_t block_size)
 {
 	block_data *new_block = malloc(sizeof(block_data));
 	if (new_block == NULL)
@@ -136,7 +136,7 @@ void destroy_block_list(block_data *block_list)
 	}
 }
 
-static block_data *find_block(u_int32_t blk_number, block_data  *block_list)
+static block_data *find_block(uint32_t blk_number, block_data  *block_list)
 {
 	while (block_list) {
 		if (block_list->blk_number == blk_number)
@@ -149,9 +149,9 @@ static block_data *find_block(u_int32_t blk_number, block_data  *block_list)
 }
 
 /* Returns pointer to block after adding it to block_list, if needed. */
-static block_data *add_block(u_int32_t blk_number,
+static block_data *add_block(uint32_t blk_number,
 		block_data **block_list,
-		u_int32_t block_size)
+		uint32_t block_size)
 {
 	block_data *block = find_block(blk_number,*block_list);
 	block_data *parent;
@@ -183,7 +183,7 @@ static block_data *add_block(u_int32_t blk_number,
 }
 
 static int
-erase_block(build_image_context *context, u_int32_t blk_number)
+erase_block(build_image_context *context, uint32_t blk_number)
 {
 	block_data   *block;
 
@@ -203,12 +203,12 @@ erase_block(build_image_context *context, u_int32_t blk_number)
 
 static int
 write_page(build_image_context *context,
-	u_int32_t blk_number,
-	u_int32_t page_number,
-	u_int8_t *data)
+	uint32_t blk_number,
+	uint32_t page_number,
+	uint8_t *data)
 {
 	block_data *block;
-	u_int8_t *page_ptr;
+	uint8_t *page_ptr;
 
 	assert(context);
 
@@ -234,10 +234,10 @@ write_page(build_image_context *context,
 }
 
 static void
-insert_padding(u_int8_t *data, u_int32_t length)
+insert_padding(uint8_t *data, uint32_t length)
 {
-	u_int32_t aes_blks;
-	u_int32_t remaining;
+	uint32_t aes_blks;
+	uint32_t remaining;
 
 	aes_blks = iceil_log2(length, NVBOOT_AES_BLOCK_SIZE_LOG2);
 	remaining = (aes_blks << NVBOOT_AES_BLOCK_SIZE_LOG2) - length;
@@ -246,9 +246,9 @@ insert_padding(u_int8_t *data, u_int32_t length)
 }
 
 static void
-write_padding(u_int8_t *p, u_int32_t remaining)
+write_padding(uint8_t *p, uint32_t remaining)
 {
-	u_int8_t value = 0x80;
+	uint8_t value = 0x80;
 
 	while (remaining) {
 		*p++ = value;
@@ -259,14 +259,14 @@ write_padding(u_int8_t *p, u_int32_t remaining)
 
 static int
 write_bct(build_image_context *context,
-	u_int32_t block,
-	u_int32_t bct_slot)
+	uint32_t block,
+	uint32_t bct_slot)
 {
-	u_int32_t pagesremaining;
-	u_int32_t page;
-	u_int32_t pages_per_bct;
-	u_int8_t *buffer;
-	u_int8_t *data;
+	uint32_t pagesremaining;
+	uint32_t page;
+	uint32_t pages_per_bct;
+	uint8_t *buffer;
+	uint8_t *data;
 	int err = 0;
 
 	assert(context);
@@ -322,7 +322,7 @@ g_soc_config->getbl_param(instance,            \
 
 #define COPY_BL_FIELD(from, to, field)         \
 do {                                           \
-    u_int32_t v;                               \
+    uint32_t v;                               \
     GET_BL_FIELD(from, field, &v);             \
     SET_BL_FIELD(to,   field,  v);             \
 } while (0);
@@ -343,7 +343,7 @@ g_soc_config->get_mts_info(context,             \
 
 #define COPY_MTS_FIELD(from, to, field)         \
 do {                                            \
-    u_int32_t v;                                \
+    uint32_t v;                                \
     GET_MTS_FIELD(from, field, &v);             \
     SET_MTS_FIELD(to,   field,  v);             \
 } while (0);
@@ -380,10 +380,10 @@ do {                                            \
 
 static void
 set_bl_data(build_image_context *context,
-		u_int32_t instance,
-		u_int32_t start_blk,
-		u_int32_t start_page,
-		u_int32_t length)
+		uint32_t instance,
+		uint32_t start_blk,
+		uint32_t start_page,
+		uint32_t length)
 {
 	assert(context);
 
@@ -398,10 +398,10 @@ set_bl_data(build_image_context *context,
 
 static void
 set_mts_data(build_image_context *context,
-		u_int32_t instance,
-		u_int32_t start_blk,
-		u_int32_t start_page,
-		u_int32_t length)
+		uint32_t instance,
+		uint32_t start_blk,
+		uint32_t start_page,
+		uint32_t length)
 {
 	assert(context);
 
@@ -436,25 +436,25 @@ do {                                                                      \
 static int
 write_image(build_image_context *context, file_type image_type)
 {
-	u_int32_t i, j;
-	u_int32_t image_instance;
-	u_int32_t image_move_count = 0;
-	u_int32_t image_move_remaining;
-	u_int32_t current_blk;
-	u_int32_t current_page;
-	u_int32_t pages_in_image;
-	u_int32_t image_used;
-	u_int8_t  *image_storage; /* Holds the image after reading */
-	u_int8_t  *buffer;	/* Holds the image for writing */
-	u_int8_t  *src;	/* Scans through the image during writing */
-	u_int32_t  image_actual_size; /* In bytes */
-	u_int32_t  pagesremaining;
-	u_int32_t  virtual_blk;
-	u_int32_t  pages_per_blk;
-	u_int32_t  image_version;
-	u_int8_t  *hash_buffer;
-	u_int32_t  hash_size;
-	u_int32_t  image_max;
+	uint32_t i, j;
+	uint32_t image_instance;
+	uint32_t image_move_count = 0;
+	uint32_t image_move_remaining;
+	uint32_t current_blk;
+	uint32_t current_page;
+	uint32_t pages_in_image;
+	uint32_t image_used;
+	uint8_t  *image_storage; /* Holds the image after reading */
+	uint8_t  *buffer;	/* Holds the image for writing */
+	uint8_t  *src;	/* Scans through the image during writing */
+	uint32_t  image_actual_size; /* In bytes */
+	uint32_t  pagesremaining;
+	uint32_t  virtual_blk;
+	uint32_t  pages_per_blk;
+	uint32_t  image_version;
+	uint8_t  *hash_buffer;
+	uint32_t  hash_size;
+	uint32_t  image_max;
 	parse_token token;
 	int err = 0, is_bl;
 
@@ -499,7 +499,7 @@ write_image(build_image_context *context, file_type image_type)
 	token = is_bl ? token_bootloader_used : token_mts_used;
 	g_soc_config->get_value(token, &image_used, context->bct);
 	for (image_instance = 0; image_instance < image_used; image_instance++) {
-		u_int32_t tmp;
+		uint32_t tmp;
 		GET_FIELD(is_bl, image_instance, version, &tmp);
 		if (tmp == image_version)
 			image_move_count++;
@@ -513,8 +513,8 @@ write_image(build_image_context *context, file_type image_type)
 	/* Move the mts entries down. */
 	image_move_remaining = image_move_count;
 	while (image_move_remaining > 0) {
-		u_int32_t  inst_from = image_move_remaining - 1;
-		u_int32_t  inst_to   =
+		uint32_t  inst_from = image_move_remaining - 1;
+		uint32_t  inst_to   =
 			image_move_remaining + context->redundancy - 1;
 
 		COPY_FIELD(is_bl, inst_from, inst_to, version);
@@ -528,11 +528,11 @@ write_image(build_image_context *context, file_type image_type)
 		if (is_bl) {
 			g_soc_config->getbl_param(inst_from,
 				token_bl_crypto_hash,
-				(u_int32_t*)hash_buffer,
+				(uint32_t*)hash_buffer,
 				context->bct);
 			g_soc_config->setbl_param(inst_to,
 				token_bl_crypto_hash,
-				(u_int32_t*)hash_buffer,
+				(uint32_t*)hash_buffer,
 				context->bct);
 		}
 
@@ -618,7 +618,7 @@ write_image(build_image_context *context, file_type image_type)
 					hash_buffer);
 			g_soc_config->setbl_param(image_instance,
 					token_bl_crypto_hash,
-					(u_int32_t*)hash_buffer,
+					(uint32_t*)hash_buffer,
 					context->bct);
 		}
 
@@ -662,12 +662,12 @@ write_image(build_image_context *context, file_type image_type)
 
 	if (enable_debug) {
 		for (i = 0; i < image_max; i++) {
-			u_int32_t version;
-			u_int32_t start_blk;
-			u_int32_t start_page;
-			u_int32_t length;
-			u_int32_t load_addr;
-			u_int32_t entry_point;
+			uint32_t version;
+			uint32_t start_blk;
+			uint32_t start_page;
+			uint32_t length;
+			uint32_t load_addr;
+			uint32_t entry_point;
 
 			GET_FIELD(is_bl, i, version,     &version);
 			GET_FIELD(is_bl, i, start_blk,  &start_blk);
@@ -689,11 +689,11 @@ write_image(build_image_context *context, file_type image_type)
 			if (is_bl) {
 				g_soc_config->getbl_param(i,
 					token_bl_crypto_hash,
-					(u_int32_t*)hash_buffer,
+					(uint32_t*)hash_buffer,
 					context->bct);
 				for (j = 0; j < hash_size / 4; j++) {
 					printf("%08x",
-						*((u_int32_t*)(hash_buffer + 4*j)));
+						*((uint32_t*)(hash_buffer + 4*j)));
 				}
 				printf("\n");
 			}
@@ -766,8 +766,8 @@ init_bct(struct build_image_context_rec *context)
 int
 read_bct_file(struct build_image_context_rec *context)
 {
-	u_int8_t  *bct_storage; /* Holds the Bl after reading */
-	u_int32_t  bct_actual_size; /* In bytes */
+	uint8_t  *bct_storage; /* Holds the Bl after reading */
+	uint32_t  bct_actual_size; /* In bytes */
 	file_type bct_filetype = file_type_bct;
 	int err = 0;
 
@@ -806,7 +806,7 @@ read_bct_file(struct build_image_context_rec *context)
 static void
 find_new_bct_blk(build_image_context *context)
 {
-	u_int32_t max_bct_search_blks;
+	uint32_t max_bct_search_blks;
 
 	assert(context);
 
@@ -830,9 +830,9 @@ find_new_bct_blk(build_image_context *context)
 int
 begin_update(build_image_context *context)
 {
-	u_int32_t hash_size;
-	u_int32_t reserved_size;
-	u_int32_t reserved_offset;
+	uint32_t hash_size;
+	uint32_t reserved_size;
+	uint32_t reserved_offset;
 	int err = 0;
 	int i;
 
@@ -840,8 +840,8 @@ begin_update(build_image_context *context)
 
 	/* Ensure that the BCT block & page data is current. */
 	if (enable_debug) {
-		u_int32_t block_size_log2;
-		u_int32_t page_size_log2;
+		uint32_t block_size_log2;
+		uint32_t page_size_log2;
 
 		g_soc_config->get_value(token_block_size_log2,
 			&block_size_log2, context->bct);
@@ -961,11 +961,11 @@ write_block_raw(build_image_context *context)
 {
 	block_data *block_list;
 	block_data *block;
-	u_int32_t blk_number;
-	u_int32_t last_blk;
-	u_int32_t pages_to_write;
-	u_int8_t *data;
-	u_int8_t *empty_blk = NULL;
+	uint32_t blk_number;
+	uint32_t last_blk;
+	uint32_t pages_to_write;
+	uint8_t *data;
+	uint8_t *empty_blk = NULL;
 
 	assert(context != NULL);
 	assert(context->memory);
@@ -1015,7 +1015,7 @@ write_block_raw(build_image_context *context)
 	return 0;
 }
 
-int write_data_block(FILE *fp, u_int32_t offset, u_int32_t size, u_int8_t *buffer)
+int write_data_block(FILE *fp, uint32_t offset, uint32_t size, uint8_t *buffer)
 {
 	if (fseek(fp, offset, 0))
 		return -1;
@@ -1044,8 +1044,8 @@ int data_is_valid_bct(build_image_context *context)
 
 int get_bct_size_from_image(build_image_context *context)
 {
-	u_int8_t buffer[NVBOOT_CONFIG_TABLE_SIZE_MIN];
-	u_int32_t bct_size = 0;
+	uint8_t buffer[NVBOOT_CONFIG_TABLE_SIZE_MIN];
+	uint32_t bct_size = 0;
 	FILE *fp;
 
 	fp = fopen(context->input_image_filename, "r");
@@ -1069,13 +1069,13 @@ int get_bct_size_from_image(build_image_context *context)
 int resign_bl(build_image_context *context)
 {
 	int ret;
-	u_int8_t  *buffer, *image;
-	u_int32_t  image_instance = 0;	/* support only one instance */
-	u_int32_t  image_actual_size; /* In bytes */
-	u_int32_t  bl_length;
-	u_int32_t  pages_in_image;
-	u_int32_t  blk_size, page_size, current_blk, current_page;
-	u_int32_t  offset;
+	uint8_t  *buffer, *image;
+	uint32_t  image_instance = 0;	/* support only one instance */
+	uint32_t  image_actual_size; /* In bytes */
+	uint32_t  bl_length;
+	uint32_t  pages_in_image;
+	uint32_t  blk_size, page_size, current_blk, current_page;
+	uint32_t  offset;
 
 	/* read in bl from image */
 	g_soc_config->get_value(token_block_size, &blk_size, context->bct);

--- a/src/data_layout.h
+++ b/src/data_layout.h
@@ -53,7 +53,7 @@ int
 write_block_raw(struct build_image_context_rec *context);
 
 int
-write_data_block(FILE *fp, u_int32_t offset, u_int32_t size, u_int8_t *buffer);
+write_data_block(FILE *fp, uint32_t offset, uint32_t size, uint8_t *buffer);
 
 int
 data_is_valid_bct(build_image_context *context);

--- a/src/nvaes_ref.h
+++ b/src/nvaes_ref.h
@@ -27,9 +27,9 @@
 #define NVAES_KEYCOLS	4
 #define NVAES_ROUNDS	10
 
-void nv_aes_expand_key(u_int8_t *key, u_int8_t *expkey);
-void nv_aes_encrypt(u_int8_t *in,
-		u_int8_t *expkey,
-		u_int8_t *out);
+void nv_aes_expand_key(uint8_t *key, uint8_t *expkey);
+void nv_aes_encrypt(uint8_t *in,
+		uint8_t *expkey,
+		uint8_t *out);
 
 #endif // INCLUDED_NVAES_REF_H

--- a/src/parse.c
+++ b/src/parse.c
@@ -40,24 +40,24 @@
 
 static int
 set_array(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t value);
-static char *parse_u32(char *str, u_int32_t *val);
-static char *parse_u8(char *str, u_int32_t *val);
-static char *parse_chipuid(char *str, u_int8_t *val);
+			uint32_t value);
+static char *parse_u32(char *str, uint32_t *val);
+static char *parse_u8(char *str, uint32_t *val);
+static char *parse_chipuid(char *str, uint8_t *val);
 static char *parse_filename(char *str, char *name, int chars_remaining);
 static char *parse_enum(build_image_context *context,
 			char *str,
 			enum_item *table,
-			u_int32_t *val);
+			uint32_t *val);
 static char
 *parse_field_name(char *rest, field_item *field_table, field_item **field);
 static char
 *parse_field_value(build_image_context *context,
 			char *rest,
 			field_item *field,
-			u_int32_t *value);
+			uint32_t *value);
 static int
 parse_array(build_image_context *context, parse_token token, char *rest);
 static int
@@ -85,7 +85,7 @@ parse_sign_bl(build_image_context *context, parse_token token, char *rest);
 
 static int process_statement(build_image_context *context,
 				char *str,
-				u_int8_t simple_parse);
+				uint8_t simple_parse);
 
 static parse_item parse_simple_items[] =
 {
@@ -138,10 +138,10 @@ static parse_item s_top_level_items[] = {
  * @return the remainder of the string after the number was parsed
  */
 static char *
-parse_u32(char *str, u_int32_t *val)
+parse_u32(char *str, uint32_t *val)
 {
-	u_int32_t value = 0;
-	u_int32_t digit;
+	uint32_t value = 0;
+	uint32_t digit;
 
 	while (*str == '0')
 		str++;
@@ -172,7 +172,7 @@ parse_u32(char *str, u_int32_t *val)
  * @return the remainder of the string after the number was parsed
  */
 static char *
-parse_u8(char *str, u_int32_t *val)
+parse_u8(char *str, uint32_t *val)
 {
 	char *retval;
 
@@ -195,7 +195,7 @@ parse_u8(char *str, u_int32_t *val)
  * @return the remainder of the string after the number was parsed
  */
 static char *
-parse_chipuid(char *str, u_int8_t *chipuid)
+parse_chipuid(char *str, uint8_t *chipuid)
 {
 	int byte_index = 0;
 	int paddings = 0;
@@ -276,8 +276,8 @@ parse_filename(char *str, char *name, int chars_remaining)
 static char
 *parse_field_name(char *rest, field_item *field_table, field_item **field)
 {
-	u_int32_t i;
-	u_int32_t field_name_len = 0;
+	uint32_t i;
+	uint32_t field_name_len = 0;
 
 	assert(field_table != NULL);
 	assert(rest != NULL);
@@ -316,7 +316,7 @@ static char
 *parse_field_value(build_image_context *context,
 			char *rest,
 			field_item *field,
-			u_int32_t *value)
+			uint32_t *value)
 {
 	assert(rest != NULL);
 	assert(field != NULL);
@@ -360,7 +360,7 @@ static char *
 parse_enum(build_image_context *context,
 		char *str,
 		enum_item *table,
-		u_int32_t *val)
+		uint32_t *val)
 {
 	int i;
 	char *rest;
@@ -392,8 +392,8 @@ static int parse_bootloader(build_image_context *context,
 {
 	char filename[MAX_BUFFER];
 	char e_state[MAX_STR_LEN];
-	u_int32_t load_addr;
-	u_int32_t entry_point;
+	uint32_t load_addr;
+	uint32_t entry_point;
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -447,8 +447,8 @@ static int parse_mts_image(build_image_context *context,
 {
 	char filename[MAX_BUFFER];
 	char e_state[MAX_STR_LEN];
-	u_int32_t load_addr;
-	u_int32_t entry_point;
+	uint32_t load_addr;
+	uint32_t entry_point;
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -528,8 +528,8 @@ static int parse_rsa_param(build_image_context *context,
 static int
 parse_array(build_image_context *context, parse_token token, char *rest)
 {
-	u_int32_t index;
-	u_int32_t value;
+	uint32_t index;
+	uint32_t value;
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -586,9 +586,9 @@ parse_array(build_image_context *context, parse_token token, char *rest)
 
 static int
 set_array(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t value)
+			uint32_t value)
 {
 	int err = 0;
 
@@ -614,7 +614,7 @@ set_array(build_image_context *context,
 }
 
 /*
- * General handler for setting u_int32_t values in config files.
+ * General handler for setting uint32_t values in config files.
  *
  * @param context	The main context pointer
  * @param token  	The parse token value
@@ -625,7 +625,7 @@ static int parse_value_u32(build_image_context *context,
 			parse_token token,
 			char *rest)
 {
-	u_int32_t value;
+	uint32_t value;
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -649,7 +649,7 @@ static int parse_value_chipuid(build_image_context *context,
 			parse_token token,
 			char *rest)
 {
-	u_int8_t value[16];
+	uint8_t value[16];
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -724,10 +724,10 @@ parse_end_state(char *str, char *uname, int chars_remaining)
 static int
 parse_dev_param(build_image_context *context, parse_token token, char *rest)
 {
-	u_int32_t i;
-	u_int32_t value;
+	uint32_t i;
+	uint32_t value;
 	field_item *field;
-	u_int32_t index;
+	uint32_t index;
 	parse_subfield_item *device_item = NULL;
 
 	assert(context != NULL);
@@ -791,9 +791,9 @@ parse_dev_param(build_image_context *context, parse_token token, char *rest)
 static int
 parse_sdram_param(build_image_context *context, parse_token token, char *rest)
 {
-	u_int32_t value;
+	uint32_t value;
 	field_item *field;
-	u_int32_t index;
+	uint32_t index;
 
 	assert(context != NULL);
 	assert(rest != NULL);
@@ -848,7 +848,7 @@ parse_sdram_param(build_image_context *context, parse_token token, char *rest)
 static int
 process_statement(build_image_context *context,
 			char *str,
-			u_int8_t simple_parse)
+			uint8_t simple_parse)
 {
 	int i;
 	char *rest;
@@ -880,15 +880,15 @@ process_statement(build_image_context *context,
  * @param context     	The main context pointer
  * @param simple_parse	Simple parse flag
  */
-void process_config_file(build_image_context *context, u_int8_t simple_parse)
+void process_config_file(build_image_context *context, uint8_t simple_parse)
 {
 	char buffer[MAX_BUFFER];
 	int  space = 0;
 	int current;
-	u_int8_t c_eol_comment_start = 0; /* True after first slash */
-	u_int8_t comment = 0;
-	u_int8_t string = 0;
-	u_int8_t equal_encounter = 0;
+	uint8_t c_eol_comment_start = 0; /* True after first slash */
+	uint8_t comment = 0;
+	uint8_t string = 0;
+	uint8_t equal_encounter = 0;
 
 	assert(context != NULL);
 	assert(context->config_file != NULL);

--- a/src/parse.h
+++ b/src/parse.h
@@ -967,21 +967,21 @@ typedef int (*process_function)(build_image_context *context,
 				char *remainder);
 
 typedef int (*process_subfield_function)(build_image_context *context,
-					u_int32_t index,
+					uint32_t index,
 					parse_token token,
-					u_int32_t value);
+					uint32_t value);
 
 
 typedef struct
 {
 	char *name;
-	u_int32_t value;
+	uint32_t value;
 } enum_item;
 
 typedef struct
 {
 	char *name;
-	u_int32_t token;
+	uint32_t token;
 	field_type type;
 	enum_item *enum_table;
 } field_item;
@@ -1017,9 +1017,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and -ENODATA for success and failure
 	 */
 	int (*set_dev_param)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t value);
+			uint32_t value);
 	/*
 	 * Get the specified device parameters from bct data stored
 	 * in context.
@@ -1031,9 +1031,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and -ENODATA for success and failure
 	 */
 	int (*get_dev_param)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t *value);
+			uint32_t *value);
 	/*
 	 * Set sdram parameters in bct according to the value listed
 	 * in config file.
@@ -1045,9 +1045,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and 1 for success and failure
 	 */
 	int (*set_sdram_param)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t value);
+			uint32_t value);
 	/*
 	 * Get the specified sdram parameters from bct data stored
 	 * in context.
@@ -1059,9 +1059,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and 1 for success and failure
 	 */
 	int (*get_sdram_param)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t *value);
+			uint32_t *value);
 	/*
 	 * Set bootloader parameters in bct according to the value listed
 	 * in config file.
@@ -1072,10 +1072,10 @@ typedef struct cbootimage_soc_config_rec {
 	 * @param bct 	Bct pointer
 	 * @return 0 and -ENODATA for success and failure
 	 */
-	int (*setbl_param)(u_int32_t set,
+	int (*setbl_param)(uint32_t set,
 			parse_token id,
-			u_int32_t *data,
-			u_int8_t *bct);
+			uint32_t *data,
+			uint8_t *bct);
 	/*
 	 * Get the specified bootloader parameters from bct data stored
 	 * in context.
@@ -1086,10 +1086,10 @@ typedef struct cbootimage_soc_config_rec {
 	 * @param bct 	Bct pointer
 	 * @return 0 and -ENODATA for success and failure
 	 */
-	int (*getbl_param)(u_int32_t set,
+	int (*getbl_param)(uint32_t set,
 			parse_token id,
-			u_int32_t *data,
-			u_int8_t *bct);
+			uint32_t *data,
+			uint8_t *bct);
 	/*
 	 * Set the specified bct value stored in context bct data structure.
 	 *
@@ -1100,7 +1100,7 @@ typedef struct cbootimage_soc_config_rec {
 	 */
 	int (*set_value)(parse_token id,
 			void *data,
-			u_int8_t *bct);
+			uint8_t *bct);
 	/*
 	 * Get the specified bct value or some constant value of clocks and
 	 * hw type.
@@ -1112,7 +1112,7 @@ typedef struct cbootimage_soc_config_rec {
 	 */
 	int (*get_value)(parse_token id,
 			void *data,
-			u_int8_t *bct);
+			uint8_t *bct);
 	/*
 	 * Get the size of specified bct field
 	 *
@@ -1131,9 +1131,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and -ENODATA for success and failure
 	 */
 	int (*set_data)(parse_token id,
-			u_int8_t *data,
-			u_int32_t  length,
-			u_int8_t *bct);
+			uint8_t *data,
+			uint32_t  length,
+			uint8_t *bct);
 
 	/*
 	 * Get the BCT structure size
@@ -1153,9 +1153,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and 1 for success and failure
 	 */
 	int (*set_mts_info)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t value);
+			uint32_t value);
 	/*
 	 * Get the specified MTS information from bct data stored
 	 * in context.
@@ -1167,9 +1167,9 @@ typedef struct cbootimage_soc_config_rec {
 	 * @return 0 and 1 for success and failure
 	 */
 	int (*get_mts_info)(build_image_context *context,
-			u_int32_t index,
+			uint32_t index,
 			parse_token token,
-			u_int32_t *value);
+			uint32_t *value);
 
 	/*
 	 * Check if the token is supported to dump
@@ -1192,7 +1192,7 @@ typedef struct cbootimage_soc_config_rec {
 	parse_subfield_item *device_type_table;
 } cbootimage_soc_config;
 
-void process_config_file(build_image_context *context, u_int8_t simple_parse);
+void process_config_file(build_image_context *context, uint8_t simple_parse);
 
 void t210_get_soc_config(build_image_context *context,
 	cbootimage_soc_config **soc_config);
@@ -1222,132 +1222,132 @@ int if_bct_is_t20_get_soc_config(build_image_context *context,
 
 int
 t132_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t132_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t132_get_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t132_set_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 
 int
 t210_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t210_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t210_get_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t210_set_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 
 int
 t124_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t124_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t124_get_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t124_set_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t114_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t114_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t114_get_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t114_set_sdram_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t30_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t30_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 int
 t30_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value);
+		uint32_t *value);
 int
 t30_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value);
+		uint32_t value);
 int
 t20_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value);
+	uint32_t *value);
 int
 t20_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value);
+	uint32_t value);
 
 int
 t20_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value);
+		uint32_t *value);
 int
 t20_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value);
+		uint32_t value);
 
-u_int32_t iceil_log2(u_int32_t a, u_int32_t b);
+uint32_t iceil_log2(uint32_t a, uint32_t b);
 
 /* Returns the smallest power of 2 >= a */
-u_int32_t ceil_log2(u_int32_t a);
+uint32_t ceil_log2(uint32_t a);
 
 extern cbootimage_soc_config *g_soc_config;
 

--- a/src/set.c
+++ b/src/set.c
@@ -43,10 +43,10 @@
 
 int
 read_from_image(char	*filename,
-		u_int32_t	offset,
-		u_int32_t	max_size,
-		u_int8_t	**image,
-		u_int32_t	*actual_size,
+		uint32_t	offset,
+		uint32_t	max_size,
+		uint8_t	**image,
+		uint32_t	*actual_size,
 		file_type	f_type)
 {
 	int result = 0; /* 0 = success, 1 = failure */
@@ -79,7 +79,7 @@ read_from_image(char	*filename,
 			result = 1;
 			goto cleanup;
 		}
-		*actual_size = (u_int32_t)stats.st_size;
+		*actual_size = (uint32_t)stats.st_size;
 	} else {
 		if ((stats.st_size - offset) < max_size)
 			*actual_size = stats.st_size - offset;
@@ -118,8 +118,8 @@ cleanup:
 int
 set_bootloader(build_image_context	*context,
 		char	*filename,
-		u_int32_t	load_addr,
-		u_int32_t	entry_point)
+		uint32_t	load_addr,
+		uint32_t	entry_point)
 {
 	context->newbl_filename = filename;
 	context->newbl_load_addr = load_addr;
@@ -139,8 +139,8 @@ set_bootloader(build_image_context	*context,
 int
 set_mts_image(build_image_context	*context,
 		char	*filename,
-		u_int32_t	load_addr,
-		u_int32_t	entry_point)
+		uint32_t	load_addr,
+		uint32_t	entry_point)
 {
 	context->mts_filename = filename;
 	context->mts_load_addr = load_addr;
@@ -153,9 +153,9 @@ set_rsa_param(build_image_context *context, parse_token token,
 		char *filename)
 {
 	int	result;
-	u_int8_t *rsa_storage;	/* Holds the rsa param after reading */
+	uint8_t *rsa_storage;	/* Holds the rsa param after reading */
 	int32_t size;		/* Bytes to read */
-	u_int32_t actual_size;	/* In bytes */
+	uint32_t actual_size;	/* In bytes */
 
 	if ((size = g_soc_config->get_value_size(token)) <= 0)  {
 		printf("Error: Unsupported token %d for value size.\n", token);
@@ -165,7 +165,7 @@ set_rsa_param(build_image_context *context, parse_token token,
 	/* Read the image into memory. */
 	result = read_from_image(filename,
 				0,
-				(u_int32_t)size,
+				(uint32_t)size,
 				&rsa_storage,
 				&actual_size,
 				file_type_bin);
@@ -213,19 +213,19 @@ int context_set_value(build_image_context *context,
 
 	switch (token) {
 	case token_attribute:
-		context->newbl_attr = *((u_int32_t *)value);
+		context->newbl_attr = *((uint32_t *)value);
 		break;
 
 	case token_block_size:
-		context->block_size = *((u_int32_t *)value);
-		context->block_size_log2 = log2(*((u_int32_t *)value));
+		context->block_size = *((uint32_t *)value);
+		context->block_size_log2 = log2(*((uint32_t *)value));
 
 		if (context->memory != NULL) {
 			printf("Error: Too late to change block size.\n");
 			return 1;
 		}
 
-		if (context->block_size != (u_int32_t)(1 << context->block_size_log2)) {
+		if (context->block_size != (uint32_t)(1 << context->block_size_log2)) {
 			printf("Error: Block size must be a power of 2.\n");
 			return 1;
 		}
@@ -241,16 +241,16 @@ int context_set_value(build_image_context *context,
 			return 1;
 		}
 
-		context->partition_size= *((u_int32_t *)value);
+		context->partition_size= *((uint32_t *)value);
 		g_soc_config->set_value(token_partition_size,
 			value, context->bct);
 		break;
 
 	case token_page_size:
-		context->page_size = *((u_int32_t *)value);
-		context->page_size_log2 = log2(*((u_int32_t *)value));
+		context->page_size = *((uint32_t *)value);
+		context->page_size_log2 = log2(*((uint32_t *)value));
 
-		if (context->page_size != (u_int32_t)(1 << context->page_size_log2)) {
+		if (context->page_size != (uint32_t)(1 << context->page_size_log2)) {
 			printf("Error: Page size must be a power of 2.\n");
 			return 1;
 		}
@@ -261,19 +261,19 @@ int context_set_value(build_image_context *context,
 			&(context->page_size_log2), context->bct);
 		break;
 	case token_redundancy:
-		context->redundancy = *((u_int32_t *)value);
+		context->redundancy = *((uint32_t *)value);
 		break;
 
 	case token_version:
-		context->version = *((u_int32_t *)value);
+		context->version = *((uint32_t *)value);
 		break;
 
 	case token_bct_copy:
-		context->bct_copy = *((u_int32_t *)value);
+		context->bct_copy = *((uint32_t *)value);
 		break;
 
 	case token_odm_data:
-		context->odm_data = *((u_int32_t *)value);
+		context->odm_data = *((uint32_t *)value);
 		break;
 
 	case token_pre_bct_pad_blocks:
@@ -281,17 +281,17 @@ int context_set_value(build_image_context *context,
 			printf("Error: Too late to pre-BCT pad.\n");
 			return 1;
 		}
-		context->pre_bct_pad_blocks = *((u_int32_t *)value);
+		context->pre_bct_pad_blocks = *((uint32_t *)value);
 		break;
 
 	case token_secure_jtag_control:
-		context->secure_jtag_control = *((u_int32_t *)value);
+		context->secure_jtag_control = *((uint32_t *)value);
 		g_soc_config->set_value(token_secure_jtag_control,
 			value, context->bct);
 		break;
 
 	case token_secure_debug_control:
-		context->secure_debug_control = *((u_int32_t *)value);
+		context->secure_debug_control = *((uint32_t *)value);
 		g_soc_config->set_value(token_secure_debug_control,
 			value, context->bct);
 		break;

--- a/src/set.h
+++ b/src/set.h
@@ -32,14 +32,14 @@
 int
 set_bootloader(build_image_context	*context,
 		char	*filename,
-		u_int32_t	load_addr,
-		u_int32_t	entry_point);
+		uint32_t	load_addr,
+		uint32_t	entry_point);
 
 int
 set_mts_image(build_image_context	*context,
 		char	*filename,
-		u_int32_t	load_addr,
-		u_int32_t	entry_point);
+		uint32_t	load_addr,
+		uint32_t	entry_point);
 
 int
 set_rsa_param(build_image_context	*context,
@@ -53,10 +53,10 @@ context_set_value(build_image_context	*context,
 
 int
 read_from_image(char *filename,
-		u_int32_t	offset,
-		u_int32_t	max_size,
-		u_int8_t	**Image,
-		u_int32_t	*actual_size,
+		uint32_t	offset,
+		uint32_t	max_size,
+		uint8_t	**Image,
+		uint32_t	*actual_size,
 		file_type	f_type);
 
 #endif /* #ifndef INCLUDED_SET_H */

--- a/src/t114/nvbctlib_t114.c
+++ b/src/t114/nvbctlib_t114.c
@@ -59,22 +59,22 @@ case token_bl_##x:\
 #define CASE_GET_NVU32(id) \
 case token_##id:\
 	if (bct == NULL) return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -113,9 +113,9 @@ parse_token t114_root_token_list[] = {
 
 int
 t114_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -149,9 +149,9 @@ t114_set_dev_param(build_image_context *context,
 
 int
 t114_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -183,9 +183,9 @@ t114_get_dev_param(build_image_context *context,
 
 int
 t114_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -514,9 +514,9 @@ t114_get_sdram_param(build_image_context *context,
 
 int
 t114_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -846,10 +846,10 @@ t114_set_sdram_param(build_image_context *context,
 }
 
 int
-t114_getbl_param(u_int32_t set,
+t114_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -881,10 +881,10 @@ t114_getbl_param(u_int32_t set,
 }
 
 int
-t114_setbl_param(u_int32_t set,
+t114_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -916,7 +916,7 @@ t114_setbl_param(u_int32_t set,
 }
 
 int
-t114_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t114_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -944,13 +944,13 @@ t114_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	/*
@@ -967,26 +967,26 @@ t114_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)bct_ptr + sizeof(nvboot_config_table)
-				- (u_int8_t *)&(bct_ptr->random_aes_blk);
+		*((uint32_t *)data) = (uint8_t *)bct_ptr + sizeof(nvboot_config_table)
+				- (uint8_t *)&(bct_ptr->random_aes_blk);
 		break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -1012,7 +1012,7 @@ t114_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 }
 
 int
-t114_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t114_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1041,9 +1041,9 @@ t114_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t114_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1082,7 +1082,7 @@ int t114_bct_token_supported(parse_token token)
 
 void t114_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t114/nvboot_bct_t114.h
+++ b/src/t114/nvboot_bct_t114.h
@@ -110,7 +110,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /*
@@ -120,7 +120,7 @@ typedef struct nvboot_hash_rec {
 typedef struct nvboot_rsa_key_modulus_rec
 {
 	/// The modulus size is 2048-bits.
-	u_int32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_key_modulus;
 
 typedef struct nvboot_rsa_pss_sig_rec
@@ -130,7 +130,7 @@ typedef struct nvboot_rsa_pss_sig_rec
 	 * length in octets of the RSA modulus.
 	 * In our case, it's 2048-bits.
 	 */
-	u_int32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_pss_sig;
 
 typedef union nvboot_object_signature_rec
@@ -150,10 +150,10 @@ typedef union nvboot_object_signature_rec
 
 typedef struct nvboot_ecid_rec
 {
-	u_int32_t	ecid_0;
-	u_int32_t	ecid_1;
-	u_int32_t	ecid_2;
-	u_int32_t	ecid_3;
+	uint32_t	ecid_0;
+	uint32_t	ecid_1;
+	uint32_t	ecid_2;
+	uint32_t	ecid_3;
 } nvboot_ecid;
 
 /* Defines various data widths supported. */
@@ -190,7 +190,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 216MHz.  If it is set to 9, then the SDMMC
 	 * controller runs at 216/9 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -201,10 +201,10 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 
 	/* Specifies the max page size supported by driver */
-	u_int8_t multi_page_support;
+	uint8_t multi_page_support;
 } nvboot_sdmmc_params;
 
 typedef enum {
@@ -225,7 +225,7 @@ typedef struct nvboot_spiflash_params_rec {
 	/**
 	 * Specifies the clock source to use.
 	 */
-	u_int32_t clock_source;
+	uint32_t clock_source;
 
 	/**
 	 * Specifes the clock divider to use.
@@ -237,24 +237,24 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 
 	/* 0 = 2k page size, 1 = 16K page size */
-	u_int8_t page_size_2k_or_16k;
+	uint8_t page_size_2k_or_16k;
 } nvboot_spiflash_params;
 
 /**
 * Defines the union of the parameters required by each device.
 */
 typedef union {
-	u_int8_t size[64];
+	uint8_t size[64];
 	/* Specifies optimized parameters for eMMC and eSD */
 	nvboot_sdmmc_params sdmmc_params;
 	/* Specifies optimized parameters for SPI NOR */
@@ -290,13 +290,13 @@ typedef enum {
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 
 	/* Specifies the AES-CMAC MAC or RSASSA-PSS signature of the BL. */
 	nvboot_object_signature signature;
@@ -306,15 +306,15 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 	/*
 	 * Add a reserved field as padding to make the bad block table structure
 	 * a multiple of 16 bytes (AES block size).
 	 */
-	u_int8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
+	uint8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
 } nvboot_badblock_table;
 
 /**
@@ -329,27 +329,27 @@ typedef struct nvboot_config_table_rec {
 	nvboot_badblock_table badblock_table;
 	nvboot_rsa_key_modulus key;
 	nvboot_object_signature signature;
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
-	u_int32_t odm_data;
-	u_int32_t reserved1;
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
+	uint32_t odm_data;
+	uint32_t reserved1;
 
 	/* START OF SIGNED SECTION OF THE BCT */
 	nvboot_hash random_aes_blk;
 	nvboot_ecid unique_chip_id;
-	u_int32_t boot_data_version;
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;
+	uint32_t num_sdram_sets;
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS];
 
-	u_int32_t bootloader_used;
+	uint32_t bootloader_used;
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];
 
-	u_int8_t enable_fail_back;
+	uint8_t enable_fail_back;
 
 	/*
 	 * Specify whether or not to enable JTAG access when the JTAG disable fuse
@@ -357,7 +357,7 @@ typedef struct nvboot_config_table_rec {
 	 * SecureJtagControl = NV_FALSE (0) = Disable JTAG access.
 	 * SecureJtagControl = NV_TRUE (1) = Enable JTAG access.
 	 */
-	u_int8_t secure_jtag_control;
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint8_t secure_jtag_control;
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T114_H */

--- a/src/t114/nvboot_sdram_param_t114.h
+++ b/src/t114/nvboot_sdram_param_t114.h
@@ -63,342 +63,342 @@ typedef struct nvboot_sdram_params_rec {
 	/* MC/EMC clock source configuration */
 
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 	/* Specifies misc. control bits */
-	u_int32_t pllm_setup_control;
+	uint32_t pllm_setup_control;
 	/* Enables the Div by 2 */
-	u_int32_t pllm_select_div2;
+	uint32_t pllm_select_div2;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph45;
+	uint32_t pllm_pdlshift_ph45;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph90;
+	uint32_t pllm_pdlshift_ph90;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph135;
+	uint32_t pllm_pdlshift_ph135;
 	/* Specifies value for Charge Pump Gain Control */
-	u_int32_t pllm_kcp;
+	uint32_t pllm_kcp;
 	/* Specifies VCO gain */
-	u_int32_t pllm_kvco;
+	uint32_t pllm_kvco;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare0;
+	uint32_t emc_bct_spare0;
 	/* Defines EMC_2X_CLK_SRC, EMC_2X_CLK_DIVISOR, EMC_INVERT_DCD */
-	u_int32_t emc_clock_source;
+	uint32_t emc_clock_source;
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/*
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG2 */
-	u_int32_t emc_auto_cal_config2;
+	uint32_t emc_auto_cal_config2;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG3 */
-	u_int32_t emc_auto_cal_config3;
+	uint32_t emc_auto_cal_config3;
 
 	/*
 	 * Specifies the time for the calibration
 	 * to stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
 	/*
 	 * DRAM size information
 	 * Specifies the value for EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 
 	/*
 	 * Specifies the time to wait after asserting pin
 	 * CKE (in microseconds)
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 	/* Specifies the extra delay before/after pin RESET/CKE command */
-	u_int32_t emc_pin_extra_wait;
+	uint32_t emc_pin_extra_wait;
 	/*
 	 * Specifies the extra delay after the first writing
 	 * of EMC_TIMING_CONTROL
 	 */
-	u_int32_t emc_timing_control_wait;
+	uint32_t emc_timing_control_wait;
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 	/* Specifies the value for EMC_RFC_SLR */
-	u_int32_t emc_rfc_slr;
+	uint32_t emc_rfc_slr;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2R */
-	u_int32_t emc_r2r;
+	uint32_t emc_r2r;
 	/* Specifies the value for EMC_W2W */
-	u_int32_t emc_w2w;
+	uint32_t emc_w2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WEXT */
-	u_int32_t emc_wext;
+	uint32_t emc_wext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 	/* Specifies the value for EMC_WDV_MASK */
-	u_int32_t emc_wdv_mask;
+	uint32_t emc_wdv_mask;
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_IBDLY */
-	u_int32_t emc_ibdly;
+	uint32_t emc_ibdly;
 	/* Specifies the value for EMC_EINPUT */
-	u_int32_t emc_einput;
+	uint32_t emc_einput;
 	/* Specifies the value for EMC_EINPUT_DURATION */
-	u_int32_t emc_einput_duration;
+	uint32_t emc_einput_duration;
 	/* Specifies the value for EMC_PUTERM_EXTRA */
-	u_int32_t emc_puterm_extra;
+	uint32_t emc_puterm_extra;
 	/* Specifies the value for EMC_CDB_CNTL_1 */
-	u_int32_t emc_cdb_cntl1;
+	uint32_t emc_cdb_cntl1;
 	/* Specifies the value for EMC_CDB_CNTL_2 */
-	u_int32_t emc_cdb_cntl2;
+	uint32_t emc_cdb_cntl2;
 	/* Specifies the value for EMC_QRST */
-	u_int32_t emc_qrst;
+	uint32_t emc_qrst;
 	/* Specifies the value for EMC_QSAFE */
-	u_int32_t emc_qsafe;
+	uint32_t emc_qsafe;
 	/* Specifies the value for EMC_RDV */
-	u_int32_t emc_rdv;
+	uint32_t emc_rdv;
 	/* Specifies the value for EMC_RDV_MASK */
-	u_int32_t emc_rdv_mask;
+	uint32_t emc_rdv_mask;
 	/* Specifies the value for EMC_CTT */
-	u_int32_t emc_ctt;
+	uint32_t emc_ctt;
 	/* Specifies the value for EMC_CTT_DURATION */
-	u_int32_t emc_ctt_duration;
+	uint32_t emc_ctt_duration;
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PRE_REFRESH_REQ_CNT */
-	u_int32_t emc_prerefresh_req_cnt;
+	uint32_t emc_prerefresh_req_cnt;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TXSRDLL */
-	u_int32_t emc_txsr_dll;
+	uint32_t emc_txsr_dll;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TCKESR */
-	u_int32_t emc_tckesr;
+	uint32_t emc_tckesr;
 	/* Specifies the value for EMC_TPD */
-	u_int32_t emc_tpd;
+	uint32_t emc_tpd;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 	/* Specifies the value for EMC_QUSE_EXTRA */
-	u_int32_t emc_quse_extra;
+	uint32_t emc_quse_extra;
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG6 */
-	u_int32_t emc_fbio_cfg6;
+	uint32_t emc_fbio_cfg6;
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 	/* Specifies the value for EMC_CFG_RSV */
-	u_int32_t emc_cfg_rsv;
+	uint32_t emc_cfg_rsv;
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the MP0 command to initialize mode registers */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the MP2 command to initialize mode registers */
-	u_int32_t emc_emrs2;
+	uint32_t emc_emrs2;
 	/* Specifies the MP3 command to initialize mode registers */
-	u_int32_t emc_emrs3;
+	uint32_t emc_emrs3;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at cold boot */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at cold boot */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 	/* Specifies the programming to LPDDR2 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw4;
+	uint32_t emc_mrw4;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at cold boot
 	 */
-	u_int32_t emc_mrw_extra;
+	uint32_t emc_mrw_extra;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at warm boot
 	 */
-	u_int32_t emc_warm_boot_mrw_extra;
+	uint32_t emc_warm_boot_mrw_extra;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * warm boot
 	 */
-	u_int32_t emc_warm_boot_extramode_reg_write_enable;
+	uint32_t emc_warm_boot_extramode_reg_write_enable;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * cold boot
 	 */
-	u_int32_t emc_extramode_reg_write_enable;
+	uint32_t emc_extramode_reg_write_enable;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 	/* Specifies the value for EMC_MRS_WAIT_CNT */
-	u_int32_t emc_mrs_wait_cnt;
+	uint32_t emc_mrs_wait_cnt;
 	/* Specifies the value for EMC_MRS_WAIT_CNT2 */
-	u_int32_t emc_mrs_wait_cnt2;
+	uint32_t emc_mrs_wait_cnt2;
 
 	/* EMC miscellaneous configurations */
 
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 	/* Specifies the value for EMC_CMDQ */
-	u_int32_t emc_cmd_q;
+	uint32_t emc_cmd_q;
 	/* Specifies the value for EMC_MC2EMCQ */
-	u_int32_t emc_mc2emc_q;
+	uint32_t emc_mc2emc_q;
 	/* Specifies the value for EMC_DYN_SELF_REF_CONTROL */
-	u_int32_t emc_dyn_self_ref_control;
+	uint32_t emc_dyn_self_ref_control;
 
 	/* Specifies the value for MEM_INIT_DONE */
-	u_int32_t ahb_arbitration_xbar_ctrl_meminit_done;
+	uint32_t ahb_arbitration_xbar_ctrl_meminit_done;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL */
-	u_int32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll;
 	/* Specifies the value for EMC_CFG_DIG_DLL_PERIOD */
-	u_int32_t emc_cfg_dig_dll_period;
+	uint32_t emc_cfg_dig_dll_period;
 	/* Specifies the value of *DEV_SELECTN of various EMC registers */
-	u_int32_t emc_dev_select;
+	uint32_t emc_dev_select;
 
 	/* Specifies the value for EMC_SEL_DPD_CTRL */
-	u_int32_t emc_sel_dpd_ctrl;
+	uint32_t emc_sel_dpd_ctrl;
 
 	/* Pads trimmer delays */
 
 	/* Specifies the value for EMC_DLL_XFORM_DQS0 */
-	u_int32_t emc_dll_xform_dqs0;
+	uint32_t emc_dll_xform_dqs0;
 	/* Specifies the value for EMC_DLL_XFORM_DQS1 */
-	u_int32_t emc_dll_xform_dqs1;
+	uint32_t emc_dll_xform_dqs1;
 	/* Specifies the value for EMC_DLL_XFORM_DQS2 */
-	u_int32_t emc_dll_xform_dqs2;
+	uint32_t emc_dll_xform_dqs2;
 	/* Specifies the value for EMC_DLL_XFORM_DQS3 */
-	u_int32_t emc_dll_xform_dqs3;
+	uint32_t emc_dll_xform_dqs3;
 	/* Specifies the value for EMC_DLL_XFORM_DQS4 */
-	u_int32_t emc_dll_xform_dqs4;
+	uint32_t emc_dll_xform_dqs4;
 	/* Specifies the value for EMC_DLL_XFORM_DQS5 */
-	u_int32_t emc_dll_xform_dqs5;
+	uint32_t emc_dll_xform_dqs5;
 	/* Specifies the value for EMC_DLL_XFORM_DQS6 */
-	u_int32_t emc_dll_xform_dqs6;
+	uint32_t emc_dll_xform_dqs6;
 	/* Specifies the value for EMC_DLL_XFORM_DQS7 */
-	u_int32_t emc_dll_xform_dqs7;
+	uint32_t emc_dll_xform_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE0 */
-	u_int32_t emc_dll_xform_quse0;
+	uint32_t emc_dll_xform_quse0;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE1 */
-	u_int32_t emc_dll_xform_quse1;
+	uint32_t emc_dll_xform_quse1;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE2 */
-	u_int32_t emc_dll_xform_quse2;
+	uint32_t emc_dll_xform_quse2;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE3 */
-	u_int32_t emc_dll_xform_quse3;
+	uint32_t emc_dll_xform_quse3;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE4 */
-	u_int32_t emc_dll_xform_quse4;
+	uint32_t emc_dll_xform_quse4;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE5 */
-	u_int32_t emc_dll_xform_quse5;
+	uint32_t emc_dll_xform_quse5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE6 */
-	u_int32_t emc_dll_xform_quse6;
+	uint32_t emc_dll_xform_quse6;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE7 */
-	u_int32_t emc_dll_xform_quse7;
+	uint32_t emc_dll_xform_quse7;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR0 */
-	u_int32_t emc_dll_xform_addr0;
+	uint32_t emc_dll_xform_addr0;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR1 */
-	u_int32_t emc_dll_xform_addr1;
+	uint32_t emc_dll_xform_addr1;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR2 */
-	u_int32_t emc_dll_xform_addr2;
+	uint32_t emc_dll_xform_addr2;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS0 */
-	u_int32_t emc_dli_trim_tx_dqs0;
+	uint32_t emc_dli_trim_tx_dqs0;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS1 */
-	u_int32_t emc_dli_trim_tx_dqs1;
+	uint32_t emc_dli_trim_tx_dqs1;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS2 */
-	u_int32_t emc_dli_trim_tx_dqs2;
+	uint32_t emc_dli_trim_tx_dqs2;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS3 */
-	u_int32_t emc_dli_trim_tx_dqs3;
+	uint32_t emc_dli_trim_tx_dqs3;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS4 */
-	u_int32_t emc_dli_trim_tx_dqs4;
+	uint32_t emc_dli_trim_tx_dqs4;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS5 */
-	u_int32_t emc_dli_trim_tx_dqs5;
+	uint32_t emc_dli_trim_tx_dqs5;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS6 */
-	u_int32_t emc_dli_trim_tx_dqs6;
+	uint32_t emc_dli_trim_tx_dqs6;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS7 */
-	u_int32_t emc_dli_trim_tx_dqs7;
+	uint32_t emc_dli_trim_tx_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_DQ0 */
-	u_int32_t emc_dll_xform_dq0;
+	uint32_t emc_dll_xform_dq0;
 	/* Specifies the value for EMC_DLL_XFORM_DQ1 */
-	u_int32_t emc_dll_xform_dq1;
+	uint32_t emc_dll_xform_dq1;
 	/* Specifies the value for EMC_DLL_XFORM_DQ2 */
-	u_int32_t emc_dll_xform_dq2;
+	uint32_t emc_dll_xform_dq2;
 	/* Specifies the value for EMC_DLL_XFORM_DQ3 */
-	u_int32_t emc_dll_xform_dq3;
+	uint32_t emc_dll_xform_dq3;
 
 	/*
 	 * Specifies the delay after asserting CKE pin during a WarmBoot0
 	 * sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_CTT_TERM_CTRL */
-	u_int32_t emc_ctt_term_ctrl;
+	uint32_t emc_ctt_term_ctrl;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_read;
+	uint32_t emc_odt_read;
 
 	/* Periodic ZQ calibration */
 
@@ -406,399 +406,399 @@ typedef struct nvboot_sdram_params_rec {
 	 * Specifies the value for EMC_ZCAL_INTERVAL
 	 * Value 0 disables ZQ calibration
 	 */
-	u_int32_t emc_zcal_interval;
+	uint32_t emc_zcal_interval;
 	/* Specifies the value for EMC_ZCAL_WAIT_CNT */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/* Specifies the value for EMC_ZCAL_MRW_CMD */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/* DRAM initialization sequence flow control */
 
 	/* Specifies the MRS command value for resetting DLL */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the command for ZQ initialization of device 0 */
-	u_int32_t emc_zcal_init_dev0;
+	uint32_t emc_zcal_init_dev0;
 	/* Specifies the command for ZQ initialization of device 1 */
-	u_int32_t emc_zcal_init_dev1;
+	uint32_t emc_zcal_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_zcal_init_wait;
+	uint32_t emc_zcal_init_wait;
 	/* Specifies the enable for ZQ calibration at cold boot */
-	u_int32_t emc_zcal_warm_cold_boot_enables;
+	uint32_t emc_zcal_warm_cold_boot_enables;
 
 	/*
 	 * Specifies the MRW command to LPDDR2 for ZQ calibration
 	 * on warmboot
 	 */
 	/* Is issued to both devices separately */
-	u_int32_t emc_mrw_lpddr2zcal_warm_boot;
+	uint32_t emc_mrw_lpddr2zcal_warm_boot;
 	/*
 	 * Specifies the ZQ command to DDR3 for ZQ calibration on warmboot
 	 * Is issued to both devices separately
 	 */
-	u_int32_t emc_zqcal_ddr3_warm_boot;
+	uint32_t emc_zqcal_ddr3_warm_boot;
 	/*
 	 * Specifies the wait time for ZQ calibration on warmboot
 	 * (in microseconds)
 	 */
-	u_int32_t emc_zcal_warm_boot_wait;
+	uint32_t emc_zcal_warm_boot_wait;
 	/*
 	 * Specifies the enable for DRAM Mode Register programming
 	 * at warm boot
 	 */
-	u_int32_t emc_mrs_warm_boot_enable;
+	uint32_t emc_mrs_warm_boot_enable;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/* Specifies the extra MRS command to initialize mode registers */
-	u_int32_t emc_mrs_extra;
+	uint32_t emc_mrs_extra;
 	/* Specifies the extra MRS command at warm boot */
-	u_int32_t emc_warm_boot_mrs_extra;
+	uint32_t emc_warm_boot_mrs_extra;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 	/* Specifies the value for EMC_CLKEN_OVERRIDE */
-	u_int32_t emc_clken_override;
+	uint32_t emc_clken_override;
 	/*
 	 * Specifies LOG2 of the extra refresh numbers after booting
 	 * Program 0 to disable
 	 */
-	u_int32_t emc_extra_refresh_num;
+	uint32_t emc_extra_refresh_num;
 	/* Specifies the master override for all EMC clocks */
-	u_int32_t emc_clken_override_allwarm_boot;
+	uint32_t emc_clken_override_allwarm_boot;
 	/* Specifies the master override for all MC clocks */
-	u_int32_t mc_clken_override_allwarm_boot;
+	uint32_t mc_clken_override_allwarm_boot;
 	/* Specifies digital dll period, choosing between 4 to 64 ms */
-	u_int32_t emc_cfg_dig_dll_period_warm_boot;
+	uint32_t emc_cfg_dig_dll_period_warm_boot;
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel;
+	uint32_t pmc_vddp_sel;
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for PMC_DDR_CFG */
-	u_int32_t pmc_ddr_cfg;
+	uint32_t pmc_ddr_cfg;
 	/* Specifies the value for PMC_IO_DPD_REQ */
-	u_int32_t pmc_io_dpd_req;
+	uint32_t pmc_io_dpd_req;
 	/* Specifies the value for PMC_IO_DPD2_REQ */
-	u_int32_t pmc_io_dpd2_req;
+	uint32_t pmc_io_dpd2_req;
 	/* Specifies the value for PMC_REG_SHORT */
-	u_int32_t pmc_reg_short;
+	uint32_t pmc_reg_short;
 	/* Specifies the value for PMC_E_NO_VTTGEN */
-	u_int32_t pmc_eno_vtt_gen;
+	uint32_t pmc_eno_vtt_gen;
 	/* Specifies the value for PMC_NO_IOPOWER */
-	u_int32_t pmc_no_io_power;
+	uint32_t pmc_no_io_power;
 	/* Specifies the value for EMC_XM2CMDPADCTRL */
-	u_int32_t emc_xm2cmd_pad_ctrl;
+	uint32_t emc_xm2cmd_pad_ctrl;
 	/* Specifies the value for EMC_XM2CMDPADCTRL2 */
-	u_int32_t emc_xm2cmd_pad_ctrl2;
+	uint32_t emc_xm2cmd_pad_ctrl2;
 	/* Specifies the value for EMC_XM2CMDPADCTRL3 */
-	u_int32_t emc_xm2cmd_pad_ctrl3;
+	uint32_t emc_xm2cmd_pad_ctrl3;
 	/* Specifies the value for EMC_XM2CMDPADCTRL4 */
-	u_int32_t emc_xm2cmd_pad_ctrl4;
+	uint32_t emc_xm2cmd_pad_ctrl4;
 	/* Specifies the value for EMC_XM2DQSPADCTRL */
-	u_int32_t emc_xm2dqs_pad_ctrl;
+	uint32_t emc_xm2dqs_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQSPADCTRL2 */
-	u_int32_t emc_xm2dqs_pad_ctrl2;
+	uint32_t emc_xm2dqs_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQSPADCTRL3 */
-	u_int32_t emc_xm2dqs_pad_ctrl3;
+	uint32_t emc_xm2dqs_pad_ctrl3;
 	/* Specifies the value for EMC_XM2DQSPADCTRL4 */
-	u_int32_t emc_xm2dqs_pad_ctrl4;
+	uint32_t emc_xm2dqs_pad_ctrl4;
 	/* Specifies the value for EMC_XM2DQPADCTRL */
-	u_int32_t emc_xm2dq_pad_ctrl;
+	uint32_t emc_xm2dq_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQPADCTRL2 */
-	u_int32_t emc_xm2dq_pad_ctrl2;
+	uint32_t emc_xm2dq_pad_ctrl2;
 	/* Specifies the value for EMC_XM2CLKPADCTRL */
-	u_int32_t emc_xm2clk_pad_ctrl;
+	uint32_t emc_xm2clk_pad_ctrl;
 	/* Specifies the value for EMC_XM2CLKPADCTRL2 */
-	u_int32_t emc_xm2clk_pad_ctrl2;
+	uint32_t emc_xm2clk_pad_ctrl2;
 	/* Specifies the value for EMC_XM2COMPPADCTRL */
-	u_int32_t emc_xm2comp_pad_ctrl;
+	uint32_t emc_xm2comp_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL */
-	u_int32_t emc_xm2vttgen_pad_ctrl;
+	uint32_t emc_xm2vttgen_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL2 */
-	u_int32_t emc_xm2vttgen_pad_ctrl2;
+	uint32_t emc_xm2vttgen_pad_ctrl2;
 	/* Specifies the value for EMC_ACPD_CONTROL */
-	u_int32_t emc_acpd_control;
+	uint32_t emc_acpd_control;
 
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE_CFG */
-	u_int32_t emc_swizzle_rank0_byte_cfg;
+	uint32_t emc_swizzle_rank0_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
-	u_int32_t emc_swizzle_rank0_byte0;
+	uint32_t emc_swizzle_rank0_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
-	u_int32_t emc_swizzle_rank0_byte1;
+	uint32_t emc_swizzle_rank0_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE2 */
-	u_int32_t emc_swizzle_rank0_byte2;
+	uint32_t emc_swizzle_rank0_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
-	u_int32_t emc_swizzle_rank0_byte3;
+	uint32_t emc_swizzle_rank0_byte3;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE_CFG */
-	u_int32_t emc_swizzle_rank1_byte_cfg;
+	uint32_t emc_swizzle_rank1_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
-	u_int32_t emc_swizzle_rank1_byte0;
+	uint32_t emc_swizzle_rank1_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */
-	u_int32_t emc_swizzle_rank1_byte1;
+	uint32_t emc_swizzle_rank1_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE2 */
-	u_int32_t emc_swizzle_rank1_byte2;
+	uint32_t emc_swizzle_rank1_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE3 */
-	u_int32_t emc_swizzle_rank1_byte3;
+	uint32_t emc_swizzle_rank1_byte3;
 	/* Specifies the value for EMC_ADDR_SWIZZLE_STACK1A */
-	u_int32_t emc_addr_swizzle_stack1a;
+	uint32_t emc_addr_swizzle_stack1a;
 	/* Specifies the value for EMC_ADDR_SWIZZLE_STACK1B */
-	u_int32_t emc_addr_swizzle_stack1b;
+	uint32_t emc_addr_swizzle_stack1b;
 	/* Specifies the value for EMC_ADDR_SWIZZLE_STACK2A */
-	u_int32_t emc_addr_swizzle_stack2a;
+	uint32_t emc_addr_swizzle_stack2a;
 	/* Specifies the value for EMC_ADDR_SWIZZLE_STACK2B */
-	u_int32_t emc_addr_swizzle_stack2b;
+	uint32_t emc_addr_swizzle_stack2b;
 	/* Specifies the value for EMC_ADDR_SWIZZLE_STACK3 */
-	u_int32_t emc_addr_swizzle_stack3;
+	uint32_t emc_addr_swizzle_stack3;
 
 	/* Specifies the value for EMC_DSR_VTTGEN_DRV */
-	u_int32_t emc_dsr_vttgen_drv;
+	uint32_t emc_dsr_vttgen_drv;
 
 	/* Specifies the value for EMC_TXDSRVTTGEN */
-	u_int32_t emc_txdsrvttgen;
+	uint32_t emc_txdsrvttgen;
 
 	/* DRAM size information */
 
 	/* Specifies the value for MC_EMEM_ADR_CFG */
-	u_int32_t mc_emem_adr_cfg;
+	uint32_t mc_emem_adr_cfg;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV0 */
-	u_int32_t mc_emem_adr_cfg_dev0;
+	uint32_t mc_emem_adr_cfg_dev0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV1 */
-	u_int32_t mc_emem_adr_cfg_dev1;
+	uint32_t mc_emem_adr_cfg_dev1;
 	/* Specifies the value for MC_EMEM_ADR_CFG_CHANNEL_MASK */
-	u_int32_t mc_emem_adr_cfg_channel_mask;
+	uint32_t mc_emem_adr_cfg_channel_mask;
 	/* Specifies the value for MC_EMEM_ADR_CFG_CHANNEL_MASK_PROPAGATION_COUNT */
-	u_int32_t mc_emem_adr_cfg_channel_mask_propagation_count;
+	uint32_t mc_emem_adr_cfg_channel_mask_propagation_count;
 	/* Specifies the value for MC_EMEM_ADR_CFG_BANK_MASK_0 */
-	u_int32_t mc_emem_adr_cfg_bank_mask0;
+	uint32_t mc_emem_adr_cfg_bank_mask0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_BANK_MASK_1 */
-	u_int32_t mc_emem_adr_cfg_bank_mask1;
+	uint32_t mc_emem_adr_cfg_bank_mask1;
 	/* Specifies the value for MC_EMEM_ADR_CFG_BANK_MASK_2 */
-	u_int32_t mc_emem_adr_cfg_bank_mask2;
+	uint32_t mc_emem_adr_cfg_bank_mask2;
 
 	/*
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/* MC arbitration configuration */
 
 	/* Specifies the value for MC_EMEM_ARB_CFG */
-	u_int32_t mc_emem_arb_cfg;
+	uint32_t mc_emem_arb_cfg;
 	/* Specifies the value for MC_EMEM_ARB_OUTSTANDING_REQ */
-	u_int32_t mc_emem_arb_outstanding_req;
+	uint32_t mc_emem_arb_outstanding_req;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RCD */
-	u_int32_t mc_emem_arb_timing_rcd;
+	uint32_t mc_emem_arb_timing_rcd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RP */
-	u_int32_t mc_emem_arb_timing_rp;
+	uint32_t mc_emem_arb_timing_rp;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RC */
-	u_int32_t mc_emem_arb_timing_rc;
+	uint32_t mc_emem_arb_timing_rc;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAS */
-	u_int32_t mc_emem_arb_timing_ras;
+	uint32_t mc_emem_arb_timing_ras;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_FAW */
-	u_int32_t mc_emem_arb_timing_faw;
+	uint32_t mc_emem_arb_timing_faw;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RRD */
-	u_int32_t mc_emem_arb_timing_rrd;
+	uint32_t mc_emem_arb_timing_rrd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAP2PRE */
-	u_int32_t mc_emem_arb_timing_rap2pre;
+	uint32_t mc_emem_arb_timing_rap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_WAP2PRE */
-	u_int32_t mc_emem_arb_timing_wap2pre;
+	uint32_t mc_emem_arb_timing_wap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2R */
-	u_int32_t mc_emem_arb_timing_r2r;
+	uint32_t mc_emem_arb_timing_r2r;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2W */
-	u_int32_t mc_emem_arb_timing_w2w;
+	uint32_t mc_emem_arb_timing_w2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2W */
-	u_int32_t mc_emem_arb_timing_r2w;
+	uint32_t mc_emem_arb_timing_r2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2R */
-	u_int32_t mc_emem_arb_timing_w2r;
+	uint32_t mc_emem_arb_timing_w2r;
 	/* Specifies the value for MC_EMEM_ARB_DA_TURNS */
-	u_int32_t mc_emem_arb_da_turns;
+	uint32_t mc_emem_arb_da_turns;
 	/* Specifies the value for MC_EMEM_ARB_DA_COVERS */
-	u_int32_t mc_emem_arb_da_covers;
+	uint32_t mc_emem_arb_da_covers;
 	/* Specifies the value for MC_EMEM_ARB_MISC0 */
-	u_int32_t mc_emem_arb_misc0;
+	uint32_t mc_emem_arb_misc0;
 	/* Specifies the value for MC_EMEM_ARB_MISC1 */
-	u_int32_t mc_emem_arb_misc1;
+	uint32_t mc_emem_arb_misc1;
 	/* Specifies the value for MC_EMEM_ARB_RING1_THROTTLE */
-	u_int32_t mc_emem_arb_ring1_throttle;
+	uint32_t mc_emem_arb_ring1_throttle;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE */
-	u_int32_t mc_emem_arb_override;
+	uint32_t mc_emem_arb_override;
 	/* Specifies the value for MC_EMEM_ARB_RSV */
-	u_int32_t mc_emem_arb_rsv;
+	uint32_t mc_emem_arb_rsv;
 
 	/* Specifies the value for MC_CLKEN_OVERRIDE */
-	u_int32_t mc_clken_override;
+	uint32_t mc_clken_override;
 
 	/* Specifies the MC/EMC register address aperture */
-	u_int32_t mc_emc_reg_mode;
+	uint32_t mc_emc_reg_mode;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM */
-	u_int32_t mc_video_protect_bom;
+	uint32_t mc_video_protect_bom;
 	/* Specifies the value for MC_VIDEO_PROTECT_SIZE_MB */
-	u_int32_t mc_video_protect_size_mb;
+	uint32_t mc_video_protect_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE */
-	u_int32_t mc_video_protect_vpr_override;
+	uint32_t mc_video_protect_vpr_override;
 	/* Specifies the value for MC_SEC_CARVEOUT_BOM */
-	u_int32_t mc_sec_carveout_bom;
+	uint32_t mc_sec_carveout_bom;
 	/* Specifies the value for MC_SEC_CARVEOUT_SIZE_MB */
-	u_int32_t mc_sec_carveout_size_mb;
+	uint32_t mc_sec_carveout_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_REG_CTRL.VIDEO_PROTECT_WRITE_ACCESS */
-	u_int32_t mc_video_protect_write_access;
+	uint32_t mc_video_protect_write_access;
 	/* Specifies the value for MC_SEC_CARVEOUT_REG_CTRL.SEC_CARVEOUT_WRITE_ACCESS */
-	u_int32_t mc_sec_carveout_protect_write_access;
+	uint32_t mc_sec_carveout_protect_write_access;
 
 	/* Specifies enable for CA training */
-	u_int32_t emc_ca_training_enable;
+	uint32_t emc_ca_training_enable;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL1 */
-	u_int32_t emc_ca_training_timing_cntl1;
+	uint32_t emc_ca_training_timing_cntl1;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL2 */
-	u_int32_t emc_ca_training_timing_cntl2;
+	uint32_t emc_ca_training_timing_cntl2;
 	/* Set if bit 6 select is greater than bit 7 select; uses aremc.spec packet SWIZZLE_BIT6_GT_BIT7 */
-	u_int32_t swizzle_rank_byte_encode;
+	uint32_t swizzle_rank_byte_encode;
 	/* Specifies enable and offset for patched boot rom write */
-	u_int32_t boot_rom_patch_control;
+	uint32_t boot_rom_patch_control;
 	/* Specifies data for patched boot rom write */
-	u_int32_t boot_rom_patch_data;
+	uint32_t boot_rom_patch_data;
 
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS0 */
-	u_int32_t ch1_emc_dll_xform_dqs0;
+	uint32_t ch1_emc_dll_xform_dqs0;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS1 */
-	u_int32_t ch1_emc_dll_xform_dqs1;
+	uint32_t ch1_emc_dll_xform_dqs1;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS2 */
-	u_int32_t ch1_emc_dll_xform_dqs2;
+	uint32_t ch1_emc_dll_xform_dqs2;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS3 */
-	u_int32_t ch1_emc_dll_xform_dqs3;
+	uint32_t ch1_emc_dll_xform_dqs3;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS4 */
-	u_int32_t ch1_emc_dll_xform_dqs4;
+	uint32_t ch1_emc_dll_xform_dqs4;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS5 */
-	u_int32_t ch1_emc_dll_xform_dqs5;
+	uint32_t ch1_emc_dll_xform_dqs5;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS6 */
-	u_int32_t ch1_emc_dll_xform_dqs6;
+	uint32_t ch1_emc_dll_xform_dqs6;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQS7 */
-	u_int32_t ch1_emc_dll_xform_dqs7;
+	uint32_t ch1_emc_dll_xform_dqs7;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE0 */
-	u_int32_t ch1_emc_dll_xform_quse0;
+	uint32_t ch1_emc_dll_xform_quse0;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE1 */
-	u_int32_t ch1_emc_dll_xform_quse1;
+	uint32_t ch1_emc_dll_xform_quse1;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE2 */
-	u_int32_t ch1_emc_dll_xform_quse2;
+	uint32_t ch1_emc_dll_xform_quse2;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE3 */
-	u_int32_t ch1_emc_dll_xform_quse3;
+	uint32_t ch1_emc_dll_xform_quse3;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE4 */
-	u_int32_t ch1_emc_dll_xform_quse4;
+	uint32_t ch1_emc_dll_xform_quse4;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE5 */
-	u_int32_t ch1_emc_dll_xform_quse5;
+	uint32_t ch1_emc_dll_xform_quse5;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE6 */
-	u_int32_t ch1_emc_dll_xform_quse6;
+	uint32_t ch1_emc_dll_xform_quse6;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_QUSE7 */
-	u_int32_t ch1_emc_dll_xform_quse7;
+	uint32_t ch1_emc_dll_xform_quse7;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS0 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs0;
+	uint32_t ch1_emc_dli_trim_tx_dqs0;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS1 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs1;
+	uint32_t ch1_emc_dli_trim_tx_dqs1;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS2 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs2;
+	uint32_t ch1_emc_dli_trim_tx_dqs2;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS3 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs3;
+	uint32_t ch1_emc_dli_trim_tx_dqs3;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS4 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs4;
+	uint32_t ch1_emc_dli_trim_tx_dqs4;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS5 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs5;
+	uint32_t ch1_emc_dli_trim_tx_dqs5;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS6 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs6;
+	uint32_t ch1_emc_dli_trim_tx_dqs6;
 	/* (Channel 1) Specifies the value for EMC_DLI_TRIM_TXDQS7 */
-	u_int32_t ch1_emc_dli_trim_tx_dqs7;
+	uint32_t ch1_emc_dli_trim_tx_dqs7;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQ0 */
-	u_int32_t ch1_emc_dll_xform_dq0;
+	uint32_t ch1_emc_dll_xform_dq0;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQ1 */
-	u_int32_t ch1_emc_dll_xform_dq1;
+	uint32_t ch1_emc_dll_xform_dq1;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQ2 */
-	u_int32_t ch1_emc_dll_xform_dq2;
+	uint32_t ch1_emc_dll_xform_dq2;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_DQ3 */
-	u_int32_t ch1_emc_dll_xform_dq3;
+	uint32_t ch1_emc_dll_xform_dq3;
 
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK0_BYTE_CFG */
-	u_int32_t ch1_emc_swizzle_rank0_byte_cfg;
+	uint32_t ch1_emc_swizzle_rank0_byte_cfg;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
-	u_int32_t ch1_emc_swizzle_rank0_byte0;
+	uint32_t ch1_emc_swizzle_rank0_byte0;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
-	u_int32_t ch1_emc_swizzle_rank0_byte1;
+	uint32_t ch1_emc_swizzle_rank0_byte1;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK0_BYTE2 */
-	u_int32_t ch1_emc_swizzle_rank0_byte2;
+	uint32_t ch1_emc_swizzle_rank0_byte2;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
-	u_int32_t ch1_emc_swizzle_rank0_byte3;
+	uint32_t ch1_emc_swizzle_rank0_byte3;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK1_BYTE_CFG */
-	u_int32_t ch1_emc_swizzle_rank1_byte_cfg;
+	uint32_t ch1_emc_swizzle_rank1_byte_cfg;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
-	u_int32_t ch1_emc_swizzle_rank1_byte0;
+	uint32_t ch1_emc_swizzle_rank1_byte0;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */
-	u_int32_t ch1_emc_swizzle_rank1_byte1;
+	uint32_t ch1_emc_swizzle_rank1_byte1;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK1_BYTE2 */
-	u_int32_t ch1_emc_swizzle_rank1_byte2;
+	uint32_t ch1_emc_swizzle_rank1_byte2;
 	/* (Channel 1) Specifies the value for EMC_SWIZZLE_RANK1_BYTE3 */
-	u_int32_t ch1_emc_swizzle_rank1_byte3;
+	uint32_t ch1_emc_swizzle_rank1_byte3;
 	/* (Channel 1) Specifies the value for EMC_ADDR_SWIZZLE_STACK1A */
-	u_int32_t ch1_emc_addr_swizzle_stack1a;
+	uint32_t ch1_emc_addr_swizzle_stack1a;
 	/* (Channel 1) Specifies the value for EMC_ADDR_SWIZZLE_STACK1B */
-	u_int32_t ch1_emc_addr_swizzle_stack1b;
+	uint32_t ch1_emc_addr_swizzle_stack1b;
 	/* (Channel 1) Specifies the value for EMC_ADDR_SWIZZLE_STACK2A */
-	u_int32_t ch1_emc_addr_swizzle_stack2a;
+	uint32_t ch1_emc_addr_swizzle_stack2a;
 	/* (Channel 1) Specifies the value for EMC_ADDR_SWIZZLE_STACK2B */
-	u_int32_t ch1_emc_addr_swizzle_stack2b;
+	uint32_t ch1_emc_addr_swizzle_stack2b;
 	/* (Channel 1) Specifies the value for EMC_ADDR_SWIZZLE_STACK3 */
-	u_int32_t ch1_emc_addr_swizzle_stack3;
+	uint32_t ch1_emc_addr_swizzle_stack3;
 
 	/* (Channel 1) Specifies the value for EMC_AUTO_CAL_CONFIG */
 	/* Note: Trigger bits are set by the SDRAM code. */
-	u_int32_t ch1_emc_auto_cal_config;
+	uint32_t ch1_emc_auto_cal_config;
 	/* (Channel 1) Specifies the value for EMC_AUTO_CAL_CONFIG2 */
-	u_int32_t ch1_emc_auto_cal_config2;
+	uint32_t ch1_emc_auto_cal_config2;
 	/* (Channel 1) Specifies the value for EMC_AUTO_CAL_CONFIG3 */
-	u_int32_t ch1_emc_auto_cal_config3;
+	uint32_t ch1_emc_auto_cal_config3;
 	/* (Channel 1) Specifies the value for EMC_CDB_CNTL_1 */
-	u_int32_t ch1_emc_cdb_cntl1;
+	uint32_t ch1_emc_cdb_cntl1;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_ADDR0 */
-	u_int32_t ch1_emc_dll_xform_addr0;
+	uint32_t ch1_emc_dll_xform_addr0;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_ADDR1 */
-	u_int32_t ch1_emc_dll_xform_addr1;
+	uint32_t ch1_emc_dll_xform_addr1;
 	/* (Channel 1) Specifies the value for EMC_DLL_XFORM_ADDR2 */
-	u_int32_t ch1_emc_dll_xform_addr2;
+	uint32_t ch1_emc_dll_xform_addr2;
 	/* (Channel 1) Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t ch1_emc_fbio_spare;
+	uint32_t ch1_emc_fbio_spare;
 	/* (Channel 1) Specifies the value for EMC_XM2CLKPADCTRL */
-	u_int32_t ch1_emc_xm2_clk_pad_ctrl;
+	uint32_t ch1_emc_xm2_clk_pad_ctrl;
 	/* (Channel 1) Specifies the value for EMC_XM2CLKPADCTRL2 */
-	u_int32_t ch1_emc_xm2_clk_pad_ctrl2;
+	uint32_t ch1_emc_xm2_clk_pad_ctrl2;
 	/* (Channel 1) Specifies the value for EMC_XM2CMDPADCTRL2 */
-	u_int32_t ch1_emc_xm2_cmd_pad_ctrl2;
+	uint32_t ch1_emc_xm2_cmd_pad_ctrl2;
 	/* (Channel 1) Specifies the value for EMC_XM2CMDPADCTRL3 */
-	u_int32_t ch1_emc_xm2_cmd_pad_ctrl3;
+	uint32_t ch1_emc_xm2_cmd_pad_ctrl3;
 	/* (Channel 1) Specifies the value for EMC_XM2CMDPADCTRL4 */
-	u_int32_t ch1_emc_xm2_cmd_pad_ctrl4;
+	uint32_t ch1_emc_xm2_cmd_pad_ctrl4;
 	/* (Channel 1) Specifies the value for EMC_XM2DQPADCTRL */
-	u_int32_t ch1_emc_xm2_dq_pad_ctrl;
+	uint32_t ch1_emc_xm2_dq_pad_ctrl;
 	/* (Channel 1) Specifies the value for EMC_XM2DQPADCTRL2 */
-	u_int32_t ch1_emc_xm2_dq_pad_ctrl2;
+	uint32_t ch1_emc_xm2_dq_pad_ctrl2;
 	/* (Channel 1) Specifies the value for EMC_XM2DQSPADCTRL */
-	u_int32_t ch1_emc_xm2_dqs_pad_ctrl;
+	uint32_t ch1_emc_xm2_dqs_pad_ctrl;
 	/* (Channel 1) Specifies the value for EMC_XM2DQSPADCTRL3 */
-	u_int32_t ch1_emc_xm2_dqs_pad_ctrl3;
+	uint32_t ch1_emc_xm2_dqs_pad_ctrl3;
 	/* (Channel 1) Specifies the value for EMC_XM2DQSPADCTRL4 */
-	u_int32_t ch1_emc_xm2_dqs_pad_ctrl4;
+	uint32_t ch1_emc_xm2_dqs_pad_ctrl4;
 
 	/* End of generated code by warmboot_code_gen */
 } nvboot_sdram_params;

--- a/src/t124/nvbctlib_t124.c
+++ b/src/t124/nvbctlib_t124.c
@@ -60,22 +60,22 @@ case token_bl_##x:\
 case token_##id:\
 	if (bct == NULL) \
 		return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -121,9 +121,9 @@ parse_token t124_root_token_list[] = {
 
 int
 t124_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -157,9 +157,9 @@ t124_set_dev_param(build_image_context *context,
 
 int
 t124_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -191,9 +191,9 @@ t124_get_dev_param(build_image_context *context,
 
 int
 t124_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -521,9 +521,9 @@ t124_get_sdram_param(build_image_context *context,
 
 int
 t124_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -852,10 +852,10 @@ t124_set_sdram_param(build_image_context *context,
 }
 
 int
-t124_getbl_param(u_int32_t set,
+t124_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -880,8 +880,8 @@ t124_getbl_param(u_int32_t set,
 		break;
 
 	case token_rsa_pss_sig_bl:
-		reverse_byte_order((u_int8_t *)data,
-			(const u_int8_t *)&bct_ptr->bootloader[set].signature.rsa_pss_sig,
+		reverse_byte_order((uint8_t *)data,
+			(const uint8_t *)&bct_ptr->bootloader[set].signature.rsa_pss_sig,
 			sizeof(nvboot_rsa_pss_sig));
 		break;
 
@@ -893,10 +893,10 @@ t124_getbl_param(u_int32_t set,
 }
 
 int
-t124_setbl_param(u_int32_t set,
+t124_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -928,7 +928,7 @@ t124_setbl_param(u_int32_t set,
 }
 
 int
-t124_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t124_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -957,13 +957,13 @@ t124_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	/*
@@ -984,37 +984,37 @@ t124_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_rsa_key_modulus:
-		reverse_byte_order(data, (const u_int8_t *)&bct_ptr->key,
+		reverse_byte_order(data, (const uint8_t *)&bct_ptr->key,
 				sizeof(nvboot_rsa_key_modulus));
 		break;
 
 	case token_rsa_pss_sig_bct:
 		reverse_byte_order(data,
-			(const u_int8_t *)&bct_ptr->signature.rsa_pss_sig,
+			(const uint8_t *)&bct_ptr->signature.rsa_pss_sig,
 			sizeof(nvboot_rsa_pss_sig));
 		break;
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)bct_ptr + sizeof(nvboot_config_table)
-				- (u_int8_t *)&(bct_ptr->random_aes_blk);
+		*((uint32_t *)data) = (uint8_t *)bct_ptr + sizeof(nvboot_config_table)
+				- (uint8_t *)&(bct_ptr->random_aes_blk);
 		break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -1062,7 +1062,7 @@ t124_bct_get_value_size(parse_token id)
 }
 
 int
-t124_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t124_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1087,7 +1087,7 @@ t124_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_rsa_key_modulus:
-		reverse_byte_order((u_int8_t *)&bct_ptr->key, data,
+		reverse_byte_order((uint8_t *)&bct_ptr->key, data,
 					sizeof(nvboot_rsa_key_modulus));
 		break;
 
@@ -1097,12 +1097,12 @@ t124_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 		 * of bootloader being built in.
 		 */
 		reverse_byte_order(
-			(u_int8_t *)&bct_ptr->bootloader[0].signature.rsa_pss_sig,
+			(uint8_t *)&bct_ptr->bootloader[0].signature.rsa_pss_sig,
 			data, sizeof(nvboot_rsa_pss_sig));
 		break;
 
 	case token_rsa_pss_sig_bct:
-		reverse_byte_order((u_int8_t *)&bct_ptr->signature.rsa_pss_sig,
+		reverse_byte_order((uint8_t *)&bct_ptr->signature.rsa_pss_sig,
 			data, sizeof(nvboot_rsa_pss_sig));
 		break;
 
@@ -1115,9 +1115,9 @@ t124_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t124_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1157,7 +1157,7 @@ int t124_bct_token_supported(parse_token token)
 
 void t124_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t124/nvboot_bct_t124.h
+++ b/src/t124/nvboot_bct_t124.h
@@ -110,7 +110,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /*
@@ -119,7 +119,7 @@ typedef struct nvboot_hash_rec {
  */
 typedef struct nvboot_rsa_key_modulus_rec {
 	/* The modulus size is 2048-bits. */
-	u_int32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_key_modulus;
 
 typedef struct nvboot_rsa_pss_sig_rec {
@@ -128,7 +128,7 @@ typedef struct nvboot_rsa_pss_sig_rec {
 	 * length in octets of the RSA modulus.
 	 * In our case, it's 2048-bits.
 	 */
-	u_int32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_pss_sig;
 
 typedef struct nvboot_object_signature_rec {
@@ -146,10 +146,10 @@ typedef struct nvboot_object_signature_rec {
 } nvboot_object_signature;
 
 typedef struct nvboot_ecid_rec {
-	u_int32_t	ecid_0;
-	u_int32_t	ecid_1;
-	u_int32_t	ecid_2;
-	u_int32_t	ecid_3;
+	uint32_t	ecid_0;
+	uint32_t	ecid_1;
+	uint32_t	ecid_2;
+	uint32_t	ecid_3;
 } nvboot_ecid;
 
 /* Defines various data widths supported. */
@@ -186,7 +186,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 216MHz.  If it is set to 9, then the SDMMC
 	 * controller runs at 216/9 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -197,10 +197,10 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 
 	/* Specifies the max page size supported by driver */
-	u_int8_t multi_page_support;
+	uint8_t multi_page_support;
 } nvboot_sdmmc_params;
 
 typedef enum {
@@ -221,7 +221,7 @@ typedef struct nvboot_spiflash_params_rec {
 	/**
 	 * Specifies the clock source to use.
 	 */
-	u_int32_t clock_source;
+	uint32_t clock_source;
 
 	/**
 	 * Specifes the clock divider to use.
@@ -233,24 +233,24 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 
 	/* 0 = 2k page size, 1 = 16K page size */
-	u_int8_t page_size_2k_or_16k;
+	uint8_t page_size_2k_or_16k;
 } nvboot_spiflash_params;
 
 /**
 * Defines the union of the parameters required by each device.
 */
 typedef union {
-	u_int8_t size[64];
+	uint8_t size[64];
 	/* Specifies optimized parameters for eMMC and eSD */
 	nvboot_sdmmc_params sdmmc_params;
 	/* Specifies optimized parameters for SPI NOR */
@@ -286,13 +286,13 @@ typedef enum {
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 
 	/* Specifies the AES-CMAC MAC or RSASSA-PSS signature of the BL. */
 	nvboot_object_signature signature;
@@ -302,15 +302,15 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 	/*
 	 * Add a reserved field as padding to make the bad block table structure
 	 * a multiple of 16 bytes (AES block size).
 	 */
-	u_int8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
+	uint8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
 } nvboot_badblock_table;
 
 /**
@@ -325,27 +325,27 @@ typedef struct nvboot_config_table_rec {
 	nvboot_badblock_table badblock_table;
 	nvboot_rsa_key_modulus key;
 	nvboot_object_signature signature;
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
-	u_int32_t odm_data;
-	u_int32_t reserved1;
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
+	uint32_t odm_data;
+	uint32_t reserved1;
 
 	/* START OF SIGNED SECTION OF THE BCT */
 	nvboot_hash random_aes_blk;
 	nvboot_ecid unique_chip_id;
-	u_int32_t boot_data_version;
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;
+	uint32_t num_sdram_sets;
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS];
 
-	u_int32_t bootloader_used;
+	uint32_t bootloader_used;
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];
 
-	u_int8_t enable_fail_back;
+	uint8_t enable_fail_back;
 
 	/*
 	 * Specify whether or not to enable JTAG access when the JTAG disable fuse
@@ -353,7 +353,7 @@ typedef struct nvboot_config_table_rec {
 	 * SecureJtagControl = NV_FALSE (0) = Disable JTAG access.
 	 * SecureJtagControl = NV_TRUE (1) = Enable JTAG access.
 	 */
-	u_int8_t secure_jtag_control;
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint8_t secure_jtag_control;
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T124_H */

--- a/src/t124/nvboot_sdram_param_t124.h
+++ b/src/t124/nvboot_sdram_param_t124.h
@@ -63,436 +63,436 @@ typedef struct nvboot_sdram_params_rec {
 	/* MC/EMC clock source configuration */
 
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 	/* Specifies misc. control bits */
-	u_int32_t pllm_setup_control;
+	uint32_t pllm_setup_control;
 	/* Enables the Div by 2 */
-	u_int32_t pllm_select_div2;
+	uint32_t pllm_select_div2;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph45;
+	uint32_t pllm_pdlshift_ph45;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph90;
+	uint32_t pllm_pdlshift_ph90;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph135;
+	uint32_t pllm_pdlshift_ph135;
 	/* Specifies value for Charge Pump Gain Control */
-	u_int32_t pllm_kcp;
+	uint32_t pllm_kcp;
 	/* Specifies VCO gain */
-	u_int32_t pllm_kvco;
+	uint32_t pllm_kvco;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare0;
+	uint32_t emc_bct_spare0;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare1;
+	uint32_t emc_bct_spare1;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare2;
+	uint32_t emc_bct_spare2;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare3;
+	uint32_t emc_bct_spare3;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare4;
+	uint32_t emc_bct_spare4;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare5;
+	uint32_t emc_bct_spare5;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare6;
+	uint32_t emc_bct_spare6;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare7;
+	uint32_t emc_bct_spare7;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare8;
+	uint32_t emc_bct_spare8;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare9;
+	uint32_t emc_bct_spare9;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare10;
+	uint32_t emc_bct_spare10;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare11;
+	uint32_t emc_bct_spare11;
 	/* Defines EMC_2X_CLK_SRC, EMC_2X_CLK_DIVISOR, EMC_INVERT_DCD */
-	u_int32_t emc_clock_source;
+	uint32_t emc_clock_source;
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/*
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG2 */
-	u_int32_t emc_auto_cal_config2;
+	uint32_t emc_auto_cal_config2;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG3 */
-	u_int32_t emc_auto_cal_config3;
+	uint32_t emc_auto_cal_config3;
 
 	/*
 	 * Specifies the time for the calibration
 	 * to stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
 	/*
 	 * DRAM size information
 	 * Specifies the value for EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 
 	/*
 	 * Specifies the time to wait after asserting pin
 	 * CKE (in microseconds)
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 	/* Specifies the extra delay before/after pin RESET/CKE command */
-	u_int32_t emc_pin_extra_wait;
+	uint32_t emc_pin_extra_wait;
 	/*
 	 * Specifies the extra delay after the first writing
 	 * of EMC_TIMING_CONTROL
 	 */
-	u_int32_t emc_timing_control_wait;
+	uint32_t emc_timing_control_wait;
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 	/* Specifies the value for EMC_RFC_SLR */
-	u_int32_t emc_rfc_slr;
+	uint32_t emc_rfc_slr;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2R */
-	u_int32_t emc_r2r;
+	uint32_t emc_r2r;
 	/* Specifies the value for EMC_W2W */
-	u_int32_t emc_w2w;
+	uint32_t emc_w2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_W2R */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WEXT */
-	u_int32_t emc_wext;
+	uint32_t emc_wext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 	/* Specifies the value for EMC_WDV_MASK */
-	u_int32_t emc_wdv_mask;
+	uint32_t emc_wdv_mask;
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_QUSE_WIDTH */
-	u_int32_t emc_quse_width;
+	uint32_t emc_quse_width;
 	/* Specifies the value for EMC_IBDLY */
-	u_int32_t emc_ibdly;
+	uint32_t emc_ibdly;
 	/* Specifies the value for EMC_EINPUT */
-	u_int32_t emc_einput;
+	uint32_t emc_einput;
 	/* Specifies the value for EMC_EINPUT_DURATION */
-	u_int32_t emc_einput_duration;
+	uint32_t emc_einput_duration;
 	/* Specifies the value for EMC_PUTERM_EXTRA */
-	u_int32_t emc_puterm_extra;
+	uint32_t emc_puterm_extra;
 	/* Specifies the value for EMC_PUTERM_WIDTH */
-	u_int32_t emc_puterm_width;
+	uint32_t emc_puterm_width;
 	/* Specifies the value for EMC_PUTERM_ADJ */
-	u_int32_t emc_puterm_adj;
+	uint32_t emc_puterm_adj;
 	/* Specifies the value for EMC_CDB_CNTL_1 */
-	u_int32_t emc_cdb_cntl1;
+	uint32_t emc_cdb_cntl1;
 	/* Specifies the value for EMC_CDB_CNTL_2 */
-	u_int32_t emc_cdb_cntl2;
+	uint32_t emc_cdb_cntl2;
 	/* Specifies the value for EMC_CDB_CNTL_3 */
-	u_int32_t emc_cdb_cntl3;
+	uint32_t emc_cdb_cntl3;
 	/* Specifies the value for EMC_QRST */
-	u_int32_t emc_qrst;
+	uint32_t emc_qrst;
 	/* Specifies the value for EMC_QSAFE */
-	u_int32_t emc_qsafe;
+	uint32_t emc_qsafe;
 	/* Specifies the value for EMC_RDV */
-	u_int32_t emc_rdv;
+	uint32_t emc_rdv;
 	/* Specifies the value for EMC_RDV_MASK */
-	u_int32_t emc_rdv_mask;
+	uint32_t emc_rdv_mask;
 	/* Specifies the value for EMC_QPOP */
-	u_int32_t emc_qpop;
+	uint32_t emc_qpop;
 	/* Specifies the value for EMC_CTT */
-	u_int32_t emc_ctt;
+	uint32_t emc_ctt;
 	/* Specifies the value for EMC_CTT_DURATION */
-	u_int32_t emc_ctt_duration;
+	uint32_t emc_ctt_duration;
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PRE_REFRESH_REQ_CNT */
-	u_int32_t emc_prerefresh_req_cnt;
+	uint32_t emc_prerefresh_req_cnt;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TXSRDLL */
-	u_int32_t emc_txsr_dll;
+	uint32_t emc_txsr_dll;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TCKESR */
-	u_int32_t emc_tckesr;
+	uint32_t emc_tckesr;
 	/* Specifies the value for EMC_TPD */
-	u_int32_t emc_tpd;
+	uint32_t emc_tpd;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG6 */
-	u_int32_t emc_fbio_cfg6;
+	uint32_t emc_fbio_cfg6;
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 	/* Specifies the value for EMC_CFG_RSV */
-	u_int32_t emc_cfg_rsv;
+	uint32_t emc_cfg_rsv;
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the MP0 command to initialize mode registers */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the MP2 command to initialize mode registers */
-	u_int32_t emc_emrs2;
+	uint32_t emc_emrs2;
 	/* Specifies the MP3 command to initialize mode registers */
-	u_int32_t emc_emrs3;
+	uint32_t emc_emrs3;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at cold boot */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at cold boot */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 	/* Specifies the programming to LPDDR2 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw4;
+	uint32_t emc_mrw4;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at cold boot
 	 */
-	u_int32_t emc_mrw_extra;
+	uint32_t emc_mrw_extra;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at warm boot
 	 */
-	u_int32_t emc_warm_boot_mrw_extra;
+	uint32_t emc_warm_boot_mrw_extra;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * warm boot
 	 */
-	u_int32_t emc_warm_boot_extramode_reg_write_enable;
+	uint32_t emc_warm_boot_extramode_reg_write_enable;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * cold boot
 	 */
-	u_int32_t emc_extramode_reg_write_enable;
+	uint32_t emc_extramode_reg_write_enable;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 	/* Specifies the value for EMC_MRS_WAIT_CNT */
-	u_int32_t emc_mrs_wait_cnt;
+	uint32_t emc_mrs_wait_cnt;
 	/* Specifies the value for EMC_MRS_WAIT_CNT2 */
-	u_int32_t emc_mrs_wait_cnt2;
+	uint32_t emc_mrs_wait_cnt2;
 
 	/* EMC miscellaneous configurations */
 
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the pipe bypass controls */
-	u_int32_t emc_cfg_pipe;
+	uint32_t emc_cfg_pipe;
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 	/* Specifies the value for EMC_CMDQ */
-	u_int32_t emc_cmd_q;
+	uint32_t emc_cmd_q;
 	/* Specifies the value for EMC_MC2EMCQ */
-	u_int32_t emc_mc2emc_q;
+	uint32_t emc_mc2emc_q;
 	/* Specifies the value for EMC_DYN_SELF_REF_CONTROL */
-	u_int32_t emc_dyn_self_ref_control;
+	uint32_t emc_dyn_self_ref_control;
 
 	/* Specifies the value for MEM_INIT_DONE */
-	u_int32_t ahb_arbitration_xbar_ctrl_meminit_done;
+	uint32_t ahb_arbitration_xbar_ctrl_meminit_done;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL */
-	u_int32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll;
 	/* Specifies the value for EMC_CFG_DIG_DLL_PERIOD */
-	u_int32_t emc_cfg_dig_dll_period;
+	uint32_t emc_cfg_dig_dll_period;
 	/* Specifies the value of *DEV_SELECTN of various EMC registers */
-	u_int32_t emc_dev_select;
+	uint32_t emc_dev_select;
 
 	/* Specifies the value for EMC_SEL_DPD_CTRL */
-	u_int32_t emc_sel_dpd_ctrl;
+	uint32_t emc_sel_dpd_ctrl;
 
 	/* Pads trimmer delays */
 
 	/* Specifies the value for EMC_DLL_XFORM_DQS0 */
-	u_int32_t emc_dll_xform_dqs0;
+	uint32_t emc_dll_xform_dqs0;
 	/* Specifies the value for EMC_DLL_XFORM_DQS1 */
-	u_int32_t emc_dll_xform_dqs1;
+	uint32_t emc_dll_xform_dqs1;
 	/* Specifies the value for EMC_DLL_XFORM_DQS2 */
-	u_int32_t emc_dll_xform_dqs2;
+	uint32_t emc_dll_xform_dqs2;
 	/* Specifies the value for EMC_DLL_XFORM_DQS3 */
-	u_int32_t emc_dll_xform_dqs3;
+	uint32_t emc_dll_xform_dqs3;
 	/* Specifies the value for EMC_DLL_XFORM_DQS4 */
-	u_int32_t emc_dll_xform_dqs4;
+	uint32_t emc_dll_xform_dqs4;
 	/* Specifies the value for EMC_DLL_XFORM_DQS5 */
-	u_int32_t emc_dll_xform_dqs5;
+	uint32_t emc_dll_xform_dqs5;
 	/* Specifies the value for EMC_DLL_XFORM_DQS6 */
-	u_int32_t emc_dll_xform_dqs6;
+	uint32_t emc_dll_xform_dqs6;
 	/* Specifies the value for EMC_DLL_XFORM_DQS7 */
-	u_int32_t emc_dll_xform_dqs7;
+	uint32_t emc_dll_xform_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_DQS8 */
-	u_int32_t emc_dll_xform_dqs8;
+	uint32_t emc_dll_xform_dqs8;
 	/* Specifies the value for EMC_DLL_XFORM_DQS9 */
-	u_int32_t emc_dll_xform_dqs9;
+	uint32_t emc_dll_xform_dqs9;
 	/* Specifies the value for EMC_DLL_XFORM_DQS10 */
-	u_int32_t emc_dll_xform_dqs10;
+	uint32_t emc_dll_xform_dqs10;
 	/* Specifies the value for EMC_DLL_XFORM_DQS11 */
-	u_int32_t emc_dll_xform_dqs11;
+	uint32_t emc_dll_xform_dqs11;
 	/* Specifies the value for EMC_DLL_XFORM_DQS12 */
-	u_int32_t emc_dll_xform_dqs12;
+	uint32_t emc_dll_xform_dqs12;
 	/* Specifies the value for EMC_DLL_XFORM_DQS13 */
-	u_int32_t emc_dll_xform_dqs13;
+	uint32_t emc_dll_xform_dqs13;
 	/* Specifies the value for EMC_DLL_XFORM_DQS14 */
-	u_int32_t emc_dll_xform_dqs14;
+	uint32_t emc_dll_xform_dqs14;
 	/* Specifies the value for EMC_DLL_XFORM_DQS15 */
-	u_int32_t emc_dll_xform_dqs15;
+	uint32_t emc_dll_xform_dqs15;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE0 */
-	u_int32_t emc_dll_xform_quse0;
+	uint32_t emc_dll_xform_quse0;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE1 */
-	u_int32_t emc_dll_xform_quse1;
+	uint32_t emc_dll_xform_quse1;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE2 */
-	u_int32_t emc_dll_xform_quse2;
+	uint32_t emc_dll_xform_quse2;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE3 */
-	u_int32_t emc_dll_xform_quse3;
+	uint32_t emc_dll_xform_quse3;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE4 */
-	u_int32_t emc_dll_xform_quse4;
+	uint32_t emc_dll_xform_quse4;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE5 */
-	u_int32_t emc_dll_xform_quse5;
+	uint32_t emc_dll_xform_quse5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE6 */
-	u_int32_t emc_dll_xform_quse6;
+	uint32_t emc_dll_xform_quse6;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE7 */
-	u_int32_t emc_dll_xform_quse7;
+	uint32_t emc_dll_xform_quse7;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR0 */
-	u_int32_t emc_dll_xform_addr0;
+	uint32_t emc_dll_xform_addr0;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR1 */
-	u_int32_t emc_dll_xform_addr1;
+	uint32_t emc_dll_xform_addr1;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR2 */
-	u_int32_t emc_dll_xform_addr2;
+	uint32_t emc_dll_xform_addr2;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR3 */
-	u_int32_t emc_dll_xform_addr3;
+	uint32_t emc_dll_xform_addr3;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR4 */
-	u_int32_t emc_dll_xform_addr4;
+	uint32_t emc_dll_xform_addr4;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR5 */
-	u_int32_t emc_dll_xform_addr5;
+	uint32_t emc_dll_xform_addr5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE8 */
-	u_int32_t emc_dll_xform_quse8;
+	uint32_t emc_dll_xform_quse8;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE9 */
-	u_int32_t emc_dll_xform_quse9;
+	uint32_t emc_dll_xform_quse9;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE10 */
-	u_int32_t emc_dll_xform_quse10;
+	uint32_t emc_dll_xform_quse10;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE11 */
-	u_int32_t emc_dll_xform_quse11;
+	uint32_t emc_dll_xform_quse11;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE12 */
-	u_int32_t emc_dll_xform_quse12;
+	uint32_t emc_dll_xform_quse12;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE13 */
-	u_int32_t emc_dll_xform_quse13;
+	uint32_t emc_dll_xform_quse13;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE14 */
-	u_int32_t emc_dll_xform_quse14;
+	uint32_t emc_dll_xform_quse14;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE15 */
-	u_int32_t emc_dll_xform_quse15;
+	uint32_t emc_dll_xform_quse15;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS0 */
-	u_int32_t emc_dli_trim_tx_dqs0;
+	uint32_t emc_dli_trim_tx_dqs0;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS1 */
-	u_int32_t emc_dli_trim_tx_dqs1;
+	uint32_t emc_dli_trim_tx_dqs1;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS2 */
-	u_int32_t emc_dli_trim_tx_dqs2;
+	uint32_t emc_dli_trim_tx_dqs2;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS3 */
-	u_int32_t emc_dli_trim_tx_dqs3;
+	uint32_t emc_dli_trim_tx_dqs3;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS4 */
-	u_int32_t emc_dli_trim_tx_dqs4;
+	uint32_t emc_dli_trim_tx_dqs4;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS5 */
-	u_int32_t emc_dli_trim_tx_dqs5;
+	uint32_t emc_dli_trim_tx_dqs5;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS6 */
-	u_int32_t emc_dli_trim_tx_dqs6;
+	uint32_t emc_dli_trim_tx_dqs6;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS7 */
-	u_int32_t emc_dli_trim_tx_dqs7;
+	uint32_t emc_dli_trim_tx_dqs7;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS8 */
-	u_int32_t emc_dli_trim_tx_dqs8;
+	uint32_t emc_dli_trim_tx_dqs8;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS9 */
-	u_int32_t emc_dli_trim_tx_dqs9;
+	uint32_t emc_dli_trim_tx_dqs9;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS10 */
-	u_int32_t emc_dli_trim_tx_dqs10;
+	uint32_t emc_dli_trim_tx_dqs10;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS11 */
-	u_int32_t emc_dli_trim_tx_dqs11;
+	uint32_t emc_dli_trim_tx_dqs11;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS12 */
-	u_int32_t emc_dli_trim_tx_dqs12;
+	uint32_t emc_dli_trim_tx_dqs12;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS13 */
-	u_int32_t emc_dli_trim_tx_dqs13;
+	uint32_t emc_dli_trim_tx_dqs13;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS14 */
-	u_int32_t emc_dli_trim_tx_dqs14;
+	uint32_t emc_dli_trim_tx_dqs14;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS15 */
-	u_int32_t emc_dli_trim_tx_dqs15;
+	uint32_t emc_dli_trim_tx_dqs15;
 	/* Specifies the value for EMC_DLL_XFORM_DQ0 */
-	u_int32_t emc_dll_xform_dq0;
+	uint32_t emc_dll_xform_dq0;
 	/* Specifies the value for EMC_DLL_XFORM_DQ1 */
-	u_int32_t emc_dll_xform_dq1;
+	uint32_t emc_dll_xform_dq1;
 	/* Specifies the value for EMC_DLL_XFORM_DQ2 */
-	u_int32_t emc_dll_xform_dq2;
+	uint32_t emc_dll_xform_dq2;
 	/* Specifies the value for EMC_DLL_XFORM_DQ3 */
-	u_int32_t emc_dll_xform_dq3;
+	uint32_t emc_dll_xform_dq3;
 	/* Specifies the value for EMC_DLL_XFORM_DQ4 */
-	u_int32_t emc_dll_xform_dq4;
+	uint32_t emc_dll_xform_dq4;
 	/* Specifies the value for EMC_DLL_XFORM_DQ5 */
-	u_int32_t emc_dll_xform_dq5;
+	uint32_t emc_dll_xform_dq5;
 	/* Specifies the value for EMC_DLL_XFORM_DQ6 */
-	u_int32_t emc_dll_xform_dq6;
+	uint32_t emc_dll_xform_dq6;
 	/* Specifies the value for EMC_DLL_XFORM_DQ7 */
-	u_int32_t emc_dll_xform_dq7;
+	uint32_t emc_dll_xform_dq7;
 
 	/*
 	 * Specifies the delay after asserting CKE pin during a WarmBoot0
 	 * sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_CTT_TERM_CTRL */
-	u_int32_t emc_ctt_term_ctrl;
+	uint32_t emc_ctt_term_ctrl;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_read;
+	uint32_t emc_odt_read;
 
 	/* Periodic ZQ calibration */
 
@@ -500,302 +500,302 @@ typedef struct nvboot_sdram_params_rec {
 	 * Specifies the value for EMC_ZCAL_INTERVAL
 	 * Value 0 disables ZQ calibration
 	 */
-	u_int32_t emc_zcal_interval;
+	uint32_t emc_zcal_interval;
 	/* Specifies the value for EMC_ZCAL_WAIT_CNT */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/* Specifies the value for EMC_ZCAL_MRW_CMD */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/* DRAM initialization sequence flow control */
 
 	/* Specifies the MRS command value for resetting DLL */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the command for ZQ initialization of device 0 */
-	u_int32_t emc_zcal_init_dev0;
+	uint32_t emc_zcal_init_dev0;
 	/* Specifies the command for ZQ initialization of device 1 */
-	u_int32_t emc_zcal_init_dev1;
+	uint32_t emc_zcal_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_zcal_init_wait;
+	uint32_t emc_zcal_init_wait;
 	/*
 	 * Specifies the enable for ZQ calibration at cold boot [bit 0]
 	 * and warm boot [bit 1]
 	 */
-	u_int32_t emc_zcal_warm_cold_boot_enables;
+	uint32_t emc_zcal_warm_cold_boot_enables;
 
 	/*
 	 * Specifies the MRW command to LPDDR2 for ZQ calibration
 	 * on warmboot
 	 */
 	/* Is issued to both devices separately */
-	u_int32_t emc_mrw_lpddr2zcal_warm_boot;
+	uint32_t emc_mrw_lpddr2zcal_warm_boot;
 	/*
 	 * Specifies the ZQ command to DDR3 for ZQ calibration on warmboot
 	 * Is issued to both devices separately
 	 */
-	u_int32_t emc_zqcal_ddr3_warm_boot;
+	uint32_t emc_zqcal_ddr3_warm_boot;
 	/*
 	 * Specifies the wait time for ZQ calibration on warmboot
 	 * (in microseconds)
 	 */
-	u_int32_t emc_zcal_warm_boot_wait;
+	uint32_t emc_zcal_warm_boot_wait;
 	/*
 	 * Specifies the enable for DRAM Mode Register programming
 	 * at warm boot
 	 */
-	u_int32_t emc_mrs_warm_boot_enable;
+	uint32_t emc_mrs_warm_boot_enable;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/* Specifies the extra MRS command to initialize mode registers */
-	u_int32_t emc_mrs_extra;
+	uint32_t emc_mrs_extra;
 	/* Specifies the extra MRS command at warm boot */
-	u_int32_t emc_warm_boot_mrs_extra;
+	uint32_t emc_warm_boot_mrs_extra;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 	/* Specifies the value for EMC_CLKEN_OVERRIDE */
-	u_int32_t emc_clken_override;
+	uint32_t emc_clken_override;
 	/* Specifies the value for MC_DIS_EXTRA_SNAP_LEVELS */
-	u_int32_t mc_dis_extra_snap_levels;
+	uint32_t mc_dis_extra_snap_levels;
 	/*
 	 * Specifies LOG2 of the extra refresh numbers after booting
 	 * Program 0 to disable
 	 */
-	u_int32_t emc_extra_refresh_num;
+	uint32_t emc_extra_refresh_num;
 	/* Specifies the master override for all EMC clocks */
-	u_int32_t emc_clken_override_allwarm_boot;
+	uint32_t emc_clken_override_allwarm_boot;
 	/* Specifies the master override for all MC clocks */
-	u_int32_t mc_clken_override_allwarm_boot;
+	uint32_t mc_clken_override_allwarm_boot;
 	/* Specifies digital dll period, choosing between 4 to 64 ms */
-	u_int32_t emc_cfg_dig_dll_period_warm_boot;
+	uint32_t emc_cfg_dig_dll_period_warm_boot;
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel;
+	uint32_t pmc_vddp_sel;
 	/* Specifies the wait time after programming PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel_wait;
+	uint32_t pmc_vddp_sel_wait;
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for PMC_DDR_CFG */
-	u_int32_t pmc_ddr_cfg;
+	uint32_t pmc_ddr_cfg;
 	/* Specifies the value for PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req;
+	uint32_t pmc_io_dpd3_req;
 	/* Specifies the wait time after programming PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req_wait;
+	uint32_t pmc_io_dpd3_req_wait;
 	/* Specifies the value for PMC_REG_SHORT */
-	u_int32_t pmc_reg_short;
+	uint32_t pmc_reg_short;
 	/* Specifies the value for PMC_NO_IOPOWER */
-	u_int32_t pmc_no_io_power;
+	uint32_t pmc_no_io_power;
 	/* Specifies the wait time after programming PMC_POR_DPD_CTRL */
-	u_int32_t pmc_por_dpd_ctrl_wait;
+	uint32_t pmc_por_dpd_ctrl_wait;
 	/* Specifies the value for EMC_XM2CMDPADCTRL */
-	u_int32_t emc_xm2cmd_pad_ctrl;
+	uint32_t emc_xm2cmd_pad_ctrl;
 	/* Specifies the value for EMC_XM2CMDPADCTRL2 */
-	u_int32_t emc_xm2cmd_pad_ctrl2;
+	uint32_t emc_xm2cmd_pad_ctrl2;
 	/* Specifies the value for EMC_XM2CMDPADCTRL3 */
-	u_int32_t emc_xm2cmd_pad_ctrl3;
+	uint32_t emc_xm2cmd_pad_ctrl3;
 	/* Specifies the value for EMC_XM2CMDPADCTRL4 */
-	u_int32_t emc_xm2cmd_pad_ctrl4;
+	uint32_t emc_xm2cmd_pad_ctrl4;
 	/* Specifies the value for EMC_XM2CMDPADCTRL5 */
-	u_int32_t emc_xm2cmd_pad_ctrl5;
+	uint32_t emc_xm2cmd_pad_ctrl5;
 	/* Specifies the value for EMC_XM2DQSPADCTRL */
-	u_int32_t emc_xm2dqs_pad_ctrl;
+	uint32_t emc_xm2dqs_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQSPADCTRL2 */
-	u_int32_t emc_xm2dqs_pad_ctrl2;
+	uint32_t emc_xm2dqs_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQSPADCTRL3 */
-	u_int32_t emc_xm2dqs_pad_ctrl3;
+	uint32_t emc_xm2dqs_pad_ctrl3;
 	/* Specifies the value for EMC_XM2DQSPADCTRL4 */
-	u_int32_t emc_xm2dqs_pad_ctrl4;
+	uint32_t emc_xm2dqs_pad_ctrl4;
 	/* Specifies the value for EMC_XM2DQSPADCTRL5 */
-	u_int32_t emc_xm2dqs_pad_ctrl5;
+	uint32_t emc_xm2dqs_pad_ctrl5;
 	/* Specifies the value for EMC_XM2DQSPADCTRL6 */
-	u_int32_t emc_xm2dqs_pad_ctrl6;
+	uint32_t emc_xm2dqs_pad_ctrl6;
 	/* Specifies the value for EMC_XM2DQPADCTRL */
-	u_int32_t emc_xm2dq_pad_ctrl;
+	uint32_t emc_xm2dq_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQPADCTRL2 */
-	u_int32_t emc_xm2dq_pad_ctrl2;
+	uint32_t emc_xm2dq_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQPADCTRL3 */
-	u_int32_t emc_xm2dq_pad_ctrl3;
+	uint32_t emc_xm2dq_pad_ctrl3;
 	/* Specifies the value for EMC_XM2CLKPADCTRL */
-	u_int32_t emc_xm2clk_pad_ctrl;
+	uint32_t emc_xm2clk_pad_ctrl;
 	/* Specifies the value for EMC_XM2CLKPADCTRL2 */
-	u_int32_t emc_xm2clk_pad_ctrl2;
+	uint32_t emc_xm2clk_pad_ctrl2;
 	/* Specifies the value for EMC_XM2COMPPADCTRL */
-	u_int32_t emc_xm2comp_pad_ctrl;
+	uint32_t emc_xm2comp_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL */
-	u_int32_t emc_xm2vttgen_pad_ctrl;
+	uint32_t emc_xm2vttgen_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL2 */
-	u_int32_t emc_xm2vttgen_pad_ctrl2;
+	uint32_t emc_xm2vttgen_pad_ctrl2;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL3 */
-	u_int32_t emc_xm2vttgen_pad_ctrl3;
+	uint32_t emc_xm2vttgen_pad_ctrl3;
 	/* Specifies the value for EMC_ACPD_CONTROL */
-	u_int32_t emc_acpd_control;
+	uint32_t emc_acpd_control;
 
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE_CFG */
-	u_int32_t emc_swizzle_rank0_byte_cfg;
+	uint32_t emc_swizzle_rank0_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
-	u_int32_t emc_swizzle_rank0_byte0;
+	uint32_t emc_swizzle_rank0_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
-	u_int32_t emc_swizzle_rank0_byte1;
+	uint32_t emc_swizzle_rank0_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE2 */
-	u_int32_t emc_swizzle_rank0_byte2;
+	uint32_t emc_swizzle_rank0_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
-	u_int32_t emc_swizzle_rank0_byte3;
+	uint32_t emc_swizzle_rank0_byte3;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE_CFG */
-	u_int32_t emc_swizzle_rank1_byte_cfg;
+	uint32_t emc_swizzle_rank1_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
-	u_int32_t emc_swizzle_rank1_byte0;
+	uint32_t emc_swizzle_rank1_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */
-	u_int32_t emc_swizzle_rank1_byte1;
+	uint32_t emc_swizzle_rank1_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE2 */
-	u_int32_t emc_swizzle_rank1_byte2;
+	uint32_t emc_swizzle_rank1_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE3 */
-	u_int32_t emc_swizzle_rank1_byte3;
+	uint32_t emc_swizzle_rank1_byte3;
 
 	/* Specifies the value for EMC_DSR_VTTGEN_DRV */
-	u_int32_t emc_dsr_vttgen_drv;
+	uint32_t emc_dsr_vttgen_drv;
 
 	/* Specifies the value for EMC_TXDSRVTTGEN */
-	u_int32_t emc_txdsrvttgen;
+	uint32_t emc_txdsrvttgen;
 	/* Specifies the value for EMC_BGBIAS_CTL */
-	u_int32_t emc_bgbias_ctl0;
+	uint32_t emc_bgbias_ctl0;
 
 	/* DRAM size information */
 
 	/* Specifies the value for MC_EMEM_ADR_CFG */
-	u_int32_t mc_emem_adr_cfg;
+	uint32_t mc_emem_adr_cfg;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV0 */
-	u_int32_t mc_emem_adr_cfg_dev0;
+	uint32_t mc_emem_adr_cfg_dev0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV1 */
-	u_int32_t mc_emem_adr_cfg_dev1;
+	uint32_t mc_emem_adr_cfg_dev1;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG0 */
-	u_int32_t mc_emem_adr_cfg_bank_mask0;
+	uint32_t mc_emem_adr_cfg_bank_mask0;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG1 */
-	u_int32_t mc_emem_adr_cfg_bank_mask1;
+	uint32_t mc_emem_adr_cfg_bank_mask1;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG2 */
-	u_int32_t mc_emem_adr_cfg_bank_mask2;
+	uint32_t mc_emem_adr_cfg_bank_mask2;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG3 */
-	u_int32_t mc_emem_adr_cfg_bank_swizzle3;
+	uint32_t mc_emem_adr_cfg_bank_swizzle3;
 
 	/*
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/* MC arbitration configuration */
 
 	/* Specifies the value for MC_EMEM_ARB_CFG */
-	u_int32_t mc_emem_arb_cfg;
+	uint32_t mc_emem_arb_cfg;
 	/* Specifies the value for MC_EMEM_ARB_OUTSTANDING_REQ */
-	u_int32_t mc_emem_arb_outstanding_req;
+	uint32_t mc_emem_arb_outstanding_req;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RCD */
-	u_int32_t mc_emem_arb_timing_rcd;
+	uint32_t mc_emem_arb_timing_rcd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RP */
-	u_int32_t mc_emem_arb_timing_rp;
+	uint32_t mc_emem_arb_timing_rp;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RC */
-	u_int32_t mc_emem_arb_timing_rc;
+	uint32_t mc_emem_arb_timing_rc;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAS */
-	u_int32_t mc_emem_arb_timing_ras;
+	uint32_t mc_emem_arb_timing_ras;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_FAW */
-	u_int32_t mc_emem_arb_timing_faw;
+	uint32_t mc_emem_arb_timing_faw;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RRD */
-	u_int32_t mc_emem_arb_timing_rrd;
+	uint32_t mc_emem_arb_timing_rrd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAP2PRE */
-	u_int32_t mc_emem_arb_timing_rap2pre;
+	uint32_t mc_emem_arb_timing_rap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_WAP2PRE */
-	u_int32_t mc_emem_arb_timing_wap2pre;
+	uint32_t mc_emem_arb_timing_wap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2R */
-	u_int32_t mc_emem_arb_timing_r2r;
+	uint32_t mc_emem_arb_timing_r2r;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2W */
-	u_int32_t mc_emem_arb_timing_w2w;
+	uint32_t mc_emem_arb_timing_w2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2W */
-	u_int32_t mc_emem_arb_timing_r2w;
+	uint32_t mc_emem_arb_timing_r2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2R */
-	u_int32_t mc_emem_arb_timing_w2r;
+	uint32_t mc_emem_arb_timing_w2r;
 	/* Specifies the value for MC_EMEM_ARB_DA_TURNS */
-	u_int32_t mc_emem_arb_da_turns;
+	uint32_t mc_emem_arb_da_turns;
 	/* Specifies the value for MC_EMEM_ARB_DA_COVERS */
-	u_int32_t mc_emem_arb_da_covers;
+	uint32_t mc_emem_arb_da_covers;
 	/* Specifies the value for MC_EMEM_ARB_MISC0 */
-	u_int32_t mc_emem_arb_misc0;
+	uint32_t mc_emem_arb_misc0;
 	/* Specifies the value for MC_EMEM_ARB_MISC1 */
-	u_int32_t mc_emem_arb_misc1;
+	uint32_t mc_emem_arb_misc1;
 	/* Specifies the value for MC_EMEM_ARB_RING1_THROTTLE */
-	u_int32_t mc_emem_arb_ring1_throttle;
+	uint32_t mc_emem_arb_ring1_throttle;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE */
-	u_int32_t mc_emem_arb_override;
+	uint32_t mc_emem_arb_override;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE_1 */
-	u_int32_t mc_emem_arb_override1;
+	uint32_t mc_emem_arb_override1;
 	/* Specifies the value for MC_EMEM_ARB_RSV */
-	u_int32_t mc_emem_arb_rsv;
+	uint32_t mc_emem_arb_rsv;
 
 	/* Specifies the value for MC_CLKEN_OVERRIDE */
-	u_int32_t mc_clken_override;
+	uint32_t mc_clken_override;
 
 	/* Specifies the value for MC_STAT_CONTROL */
-	u_int32_t mc_stat_control;
+	uint32_t mc_stat_control;
 	/* Specifies the value for MC_DISPLAY_SNAP_RING */
-	u_int32_t mc_display_snap_ring;
+	uint32_t mc_display_snap_ring;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM */
-	u_int32_t mc_video_protect_bom;
+	uint32_t mc_video_protect_bom;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM_ADR_HI */
-	u_int32_t mc_video_protect_bom_adr_hi;
+	uint32_t mc_video_protect_bom_adr_hi;
 	/* Specifies the value for MC_VIDEO_PROTECT_SIZE_MB */
-	u_int32_t mc_video_protect_size_mb;
+	uint32_t mc_video_protect_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE */
-	u_int32_t mc_video_protect_vpr_override;
+	uint32_t mc_video_protect_vpr_override;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE1 */
-	u_int32_t mc_video_protect_vpr_override1;
+	uint32_t mc_video_protect_vpr_override1;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_0 */
-	u_int32_t mc_video_protect_gpu_override0;
+	uint32_t mc_video_protect_gpu_override0;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_1 */
-	u_int32_t mc_video_protect_gpu_override1;
+	uint32_t mc_video_protect_gpu_override1;
 	/* Specifies the value for MC_SEC_CARVEOUT_BOM */
-	u_int32_t mc_sec_carveout_bom;
+	uint32_t mc_sec_carveout_bom;
 	/* Specifies the value for MC_SEC_CARVEOUT_ADR_HI */
-	u_int32_t mc_sec_carveout_adr_hi;
+	uint32_t mc_sec_carveout_adr_hi;
 	/* Specifies the value for MC_SEC_CARVEOUT_SIZE_MB */
-	u_int32_t mc_sec_carveout_size_mb;
+	uint32_t mc_sec_carveout_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_REG_CTRL.VIDEO_PROTECT_WRITE_ACCESS */
-	u_int32_t mc_video_protect_write_access;
+	uint32_t mc_video_protect_write_access;
 	/* Specifies the value for MC_SEC_CARVEOUT_REG_CTRL.SEC_CARVEOUT_WRITE_ACCESS */
-	u_int32_t mc_sec_carveout_protect_write_access;
+	uint32_t mc_sec_carveout_protect_write_access;
 
 	/* Specifies enable for CA training */
-	u_int32_t emc_ca_training_enable;
+	uint32_t emc_ca_training_enable;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL1 */
-	u_int32_t emc_ca_training_timing_cntl1;
+	uint32_t emc_ca_training_timing_cntl1;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL2 */
-	u_int32_t emc_ca_training_timing_cntl2;
+	uint32_t emc_ca_training_timing_cntl2;
 	/* Set if bit 6 select is greater than bit 7 select; uses aremc.spec packet SWIZZLE_BIT6_GT_BIT7 */
-	u_int32_t swizzle_rank_byte_encode;
+	uint32_t swizzle_rank_byte_encode;
 	/* Specifies enable and offset for patched boot rom write */
-	u_int32_t boot_rom_patch_control;
+	uint32_t boot_rom_patch_control;
 	/* Specifies data for patched boot rom write */
-	u_int32_t boot_rom_patch_data;
+	uint32_t boot_rom_patch_data;
 	/* Specifies the value for MC_MTS_CARVEOUT_BOM */
-	u_int32_t mc_mts_carveout_bom;
+	uint32_t mc_mts_carveout_bom;
 	/* Specifies the value for MC_MTS_CARVEOUT_ADR_HI */
-	u_int32_t mc_mts_carveout_adr_hi;
+	uint32_t mc_mts_carveout_adr_hi;
 	/* Specifies the value for MC_MTS_CARVEOUT_SIZE_MB */
-	u_int32_t mc_mts_carveout_size_mb;
+	uint32_t mc_mts_carveout_size_mb;
 	/* Specifies the value for MC_MTS_CARVEOUT_REG_CTRL */
-	u_int32_t mc_mts_carveout_reg_ctrl;
+	uint32_t mc_mts_carveout_reg_ctrl;
 
 	/* End of generated code by warmboot_code_gen */
 } nvboot_sdram_params;

--- a/src/t132/nvbctlib_t132.c
+++ b/src/t132/nvbctlib_t132.c
@@ -60,22 +60,22 @@ case token_bl_##x:\
 case token_##id:\
 	if (bct == NULL) \
 		return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -130,9 +130,9 @@ parse_token t132_root_token_list[] = {
 
 int
 t132_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -166,9 +166,9 @@ t132_set_dev_param(build_image_context *context,
 
 int
 t132_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -200,9 +200,9 @@ t132_get_dev_param(build_image_context *context,
 
 int
 t132_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -530,9 +530,9 @@ t132_get_sdram_param(build_image_context *context,
 
 int
 t132_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -861,10 +861,10 @@ t132_set_sdram_param(build_image_context *context,
 }
 
 int
-t132_getbl_param(u_int32_t set,
+t132_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -896,10 +896,10 @@ t132_getbl_param(u_int32_t set,
 }
 
 int
-t132_setbl_param(u_int32_t set,
+t132_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -931,7 +931,7 @@ t132_setbl_param(u_int32_t set,
 }
 
 int
-t132_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t132_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -960,19 +960,19 @@ t132_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	case token_mts_used:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = bct_ptr->mts_boot_components_used;
+		*((uint32_t *)data) = bct_ptr->mts_boot_components_used;
 		break;
 
 	/*
@@ -994,26 +994,26 @@ t132_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)bct_ptr + sizeof(nvboot_config_table)
-				- (u_int8_t *)&(bct_ptr->random_aes_blk);
+		*((uint32_t *)data) = (uint8_t *)bct_ptr + sizeof(nvboot_config_table)
+				- (uint8_t *)&(bct_ptr->random_aes_blk);
 		break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -1039,7 +1039,7 @@ t132_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 }
 
 int
-t132_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t132_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1064,7 +1064,7 @@ t132_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_mts_used:
-		bct_ptr->mts_boot_components_used = *((u_int32_t *)data);
+		bct_ptr->mts_boot_components_used = *((uint32_t *)data);
 		break;
 
 	default:
@@ -1076,9 +1076,9 @@ t132_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t132_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -1107,9 +1107,9 @@ int t132_get_bct_size()
 
 int
 t132_set_mts_info(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_mts_info *mts_info;
 	nvboot_config_table *bct = NULL;
@@ -1135,9 +1135,9 @@ t132_set_mts_info(build_image_context *context,
 
 int
 t132_get_mts_info(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_mts_info *mts_info;
 	nvboot_config_table *bct = NULL;
@@ -1174,7 +1174,7 @@ int t132_bct_token_supported(parse_token token)
 
 void t132_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t132/nvboot_bct_t132.h
+++ b/src/t132/nvboot_bct_t132.h
@@ -115,7 +115,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /*
@@ -124,7 +124,7 @@ typedef struct nvboot_hash_rec {
  */
 typedef struct nvboot_rsa_key_modulus_rec {
 	/* The modulus size is 2048-bits. */
-	u_int32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_key_modulus;
 
 typedef struct nvboot_rsa_pss_sig_rec {
@@ -133,7 +133,7 @@ typedef struct nvboot_rsa_pss_sig_rec {
 	 * length in octets of the RSA modulus.
 	 * In our case, it's 2048-bits.
 	 */
-	u_int32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_pss_sig;
 
 typedef struct nvboot_object_signature_rec {
@@ -151,10 +151,10 @@ typedef struct nvboot_object_signature_rec {
 } nvboot_object_signature;
 
 typedef struct nvboot_ecid_rec {
-	u_int32_t	ecid_0;
-	u_int32_t	ecid_1;
-	u_int32_t	ecid_2;
-	u_int32_t	ecid_3;
+	uint32_t	ecid_0;
+	uint32_t	ecid_1;
+	uint32_t	ecid_2;
+	uint32_t	ecid_3;
 } nvboot_ecid;
 
 /* Defines various data widths supported. */
@@ -191,7 +191,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 216MHz.  If it is set to 9, then the SDMMC
 	 * controller runs at 216/9 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -202,10 +202,10 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 
 	/* Specifies the max page size supported by driver */
-	u_int8_t multi_page_support;
+	uint8_t multi_page_support;
 } nvboot_sdmmc_params;
 
 typedef enum {
@@ -226,7 +226,7 @@ typedef struct nvboot_spiflash_params_rec {
 	/**
 	 * Specifies the clock source to use.
 	 */
-	u_int32_t clock_source;
+	uint32_t clock_source;
 
 	/**
 	 * Specifes the clock divider to use.
@@ -238,24 +238,24 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 
 	/* 0 = 2k page size, 1 = 16K page size */
-	u_int8_t page_size_2k_or_16k;
+	uint8_t page_size_2k_or_16k;
 } nvboot_spiflash_params;
 
 /**
 * Defines the union of the parameters required by each device.
 */
 typedef union {
-	u_int8_t size[64];
+	uint8_t size[64];
 	/* Specifies optimized parameters for eMMC and eSD */
 	nvboot_sdmmc_params sdmmc_params;
 	/* Specifies optimized parameters for SPI NOR */
@@ -296,20 +296,20 @@ typedef struct nvboot_mts_info_rec
 	 * Specifies a version number for the MTS image. The assignment of
 	 * numbers is arbitrary; the numbers are only used to identify redundant.
 	 */
-	u_int32_t version;
+	uint32_t version;
 
 	/*
 	 * Specifies the first physical block on the secondary boot device
 	 * that contains the start of the MTS image. The first block can never be
 	 * a known bad block.
 	 */
-	u_int32_t start_blk;
+	uint32_t start_blk;
 
 	/*
 	 * Specifies the page within the first block that contains the start
 	 * of the MTS image.
 	 */
-	u_int32_t start_page;
+	uint32_t start_page;
 
 	/*
 	 * Specifies the length of the MTS image in bytes. MTS image must be
@@ -318,22 +318,22 @@ typedef struct nvboot_mts_info_rec
 	 * a page. Add another 16 bytes to work around this restriction if
 	 * needed.
 	 */
-	u_int32_t length;
+	uint32_t length;
 
 	/*
 	 * Specifies the starting address of the memory region into which the
 	 * MTS will be loaded. This is optional.
 	 */
-	u_int32_t load_addr;
+	uint32_t load_addr;
 
 	/* Specifies the entry point address in the loaded MTS image. Optional */
-	u_int32_t entry_point;
+	uint32_t entry_point;
 
 	/*
 	 * Specifies an attribute available for use by other code.
 	 * Not interpreted by the Boot ROM.
 	 */
-	u_int32_t attribute;
+	uint32_t attribute;
 
 } nvboot_mts_info;
 
@@ -344,13 +344,13 @@ typedef struct nvboot_mts_info_rec
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 
 	/* Specifies the AES-CMAC MAC or RSASSA-PSS signature of the BL. */
 	nvboot_object_signature signature;
@@ -360,15 +360,15 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 	/*
 	 * Add a reserved field as padding to make the bad block table structure
 	 * a multiple of 16 bytes (AES block size).
 	 */
-	u_int8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
+	uint8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
 } nvboot_badblock_table;
 
 /**
@@ -383,31 +383,31 @@ typedef struct nvboot_config_table_rec {
 	nvboot_badblock_table badblock_table;
 	nvboot_rsa_key_modulus key;
 	nvboot_object_signature signature;
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
-	u_int32_t odm_data;
-	u_int32_t reserved1;
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
+	uint32_t odm_data;
+	uint32_t reserved1;
 
 	/* START OF SIGNED SECTION OF THE BCT */
 	nvboot_hash random_aes_blk;
 	nvboot_ecid unique_chip_id;
-	u_int32_t boot_data_version;
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;
+	uint32_t num_sdram_sets;
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS];
 
-	u_int32_t bootloader_used;
+	uint32_t bootloader_used;
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];
 
 	/*
 	 * Specify the number of Mts boot components described in the mts boot
 	 * table.
 	 */
-    u_int32_t mts_boot_components_used;
+    uint32_t mts_boot_components_used;
 
     /*
      * Specify the information needed to locate and validate Denver Boot.
@@ -416,7 +416,7 @@ typedef struct nvboot_config_table_rec {
      */
 	nvboot_mts_info mts_boot_components[NVBOOT_MAX_MTS_COMPONENTS];
 
-	u_int8_t enable_fail_back;
+	uint8_t enable_fail_back;
 
 	/*
 	 * Specify whether or not to enable JTAG access when the JTAG disable fuse
@@ -424,15 +424,15 @@ typedef struct nvboot_config_table_rec {
 	 * secure_jtag_control = NV_FALSE (0) = Disable JTAG access.
 	 * secure_jtag_control = NV_TRUE (1) = Enable JTAG access.
 	 */
-	u_int8_t secure_jtag_control;
+	uint8_t secure_jtag_control;
 
     /*
      * Specify whether or not to enable denver dfd access
      * cust_denver_dfd_en = NV_FALSE (0) = Disable Dfd access.
      * cust_denver_dfd_en = NV_TRUE (1) = Enable Dfd access.
      */
-	u_int8_t cust_denver_dfd_en;
+	uint8_t cust_denver_dfd_en;
 
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T132_H */

--- a/src/t132/nvboot_sdram_param_t132.h
+++ b/src/t132/nvboot_sdram_param_t132.h
@@ -63,436 +63,436 @@ typedef struct nvboot_sdram_params_rec {
 	/* MC/EMC clock source configuration */
 
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 	/* Specifies misc. control bits */
-	u_int32_t pllm_setup_control;
+	uint32_t pllm_setup_control;
 	/* Enables the Div by 2 */
-	u_int32_t pllm_select_div2;
+	uint32_t pllm_select_div2;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph45;
+	uint32_t pllm_pdlshift_ph45;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph90;
+	uint32_t pllm_pdlshift_ph90;
 	/* Powers down VCO output Level shifter */
-	u_int32_t pllm_pdlshift_ph135;
+	uint32_t pllm_pdlshift_ph135;
 	/* Specifies value for Charge Pump Gain Control */
-	u_int32_t pllm_kcp;
+	uint32_t pllm_kcp;
 	/* Specifies VCO gain */
-	u_int32_t pllm_kvco;
+	uint32_t pllm_kvco;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare0;
+	uint32_t emc_bct_spare0;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare1;
+	uint32_t emc_bct_spare1;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare2;
+	uint32_t emc_bct_spare2;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare3;
+	uint32_t emc_bct_spare3;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare4;
+	uint32_t emc_bct_spare4;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare5;
+	uint32_t emc_bct_spare5;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare6;
+	uint32_t emc_bct_spare6;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare7;
+	uint32_t emc_bct_spare7;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare8;
+	uint32_t emc_bct_spare8;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare9;
+	uint32_t emc_bct_spare9;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare10;
+	uint32_t emc_bct_spare10;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare11;
+	uint32_t emc_bct_spare11;
 	/* Defines EMC_2X_CLK_SRC, EMC_2X_CLK_DIVISOR, EMC_INVERT_DCD */
-	u_int32_t emc_clock_source;
+	uint32_t emc_clock_source;
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/*
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG2 */
-	u_int32_t emc_auto_cal_config2;
+	uint32_t emc_auto_cal_config2;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG3 */
-	u_int32_t emc_auto_cal_config3;
+	uint32_t emc_auto_cal_config3;
 
 	/*
 	 * Specifies the time for the calibration
 	 * to stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
 	/*
 	 * DRAM size information
 	 * Specifies the value for EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 
 	/*
 	 * Specifies the time to wait after asserting pin
 	 * CKE (in microseconds)
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 	/* Specifies the extra delay before/after pin RESET/CKE command */
-	u_int32_t emc_pin_extra_wait;
+	uint32_t emc_pin_extra_wait;
 	/*
 	 * Specifies the extra delay after the first writing
 	 * of EMC_TIMING_CONTROL
 	 */
-	u_int32_t emc_timing_control_wait;
+	uint32_t emc_timing_control_wait;
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 	/* Specifies the value for EMC_RFC_SLR */
-	u_int32_t emc_rfc_slr;
+	uint32_t emc_rfc_slr;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2R */
-	u_int32_t emc_r2r;
+	uint32_t emc_r2r;
 	/* Specifies the value for EMC_W2W */
-	u_int32_t emc_w2w;
+	uint32_t emc_w2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_W2R */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WEXT */
-	u_int32_t emc_wext;
+	uint32_t emc_wext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 	/* Specifies the value for EMC_WDV_MASK */
-	u_int32_t emc_wdv_mask;
+	uint32_t emc_wdv_mask;
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_QUSE_WIDTH */
-	u_int32_t emc_quse_width;
+	uint32_t emc_quse_width;
 	/* Specifies the value for EMC_IBDLY */
-	u_int32_t emc_ibdly;
+	uint32_t emc_ibdly;
 	/* Specifies the value for EMC_EINPUT */
-	u_int32_t emc_einput;
+	uint32_t emc_einput;
 	/* Specifies the value for EMC_EINPUT_DURATION */
-	u_int32_t emc_einput_duration;
+	uint32_t emc_einput_duration;
 	/* Specifies the value for EMC_PUTERM_EXTRA */
-	u_int32_t emc_puterm_extra;
+	uint32_t emc_puterm_extra;
 	/* Specifies the value for EMC_PUTERM_WIDTH */
-	u_int32_t emc_puterm_width;
+	uint32_t emc_puterm_width;
 	/* Specifies the value for EMC_PUTERM_ADJ */
-	u_int32_t emc_puterm_adj;
+	uint32_t emc_puterm_adj;
 	/* Specifies the value for EMC_CDB_CNTL_1 */
-	u_int32_t emc_cdb_cntl1;
+	uint32_t emc_cdb_cntl1;
 	/* Specifies the value for EMC_CDB_CNTL_2 */
-	u_int32_t emc_cdb_cntl2;
+	uint32_t emc_cdb_cntl2;
 	/* Specifies the value for EMC_CDB_CNTL_3 */
-	u_int32_t emc_cdb_cntl3;
+	uint32_t emc_cdb_cntl3;
 	/* Specifies the value for EMC_QRST */
-	u_int32_t emc_qrst;
+	uint32_t emc_qrst;
 	/* Specifies the value for EMC_QSAFE */
-	u_int32_t emc_qsafe;
+	uint32_t emc_qsafe;
 	/* Specifies the value for EMC_RDV */
-	u_int32_t emc_rdv;
+	uint32_t emc_rdv;
 	/* Specifies the value for EMC_RDV_MASK */
-	u_int32_t emc_rdv_mask;
+	uint32_t emc_rdv_mask;
 	/* Specifies the value for EMC_QPOP */
-	u_int32_t emc_qpop;
+	uint32_t emc_qpop;
 	/* Specifies the value for EMC_CTT */
-	u_int32_t emc_ctt;
+	uint32_t emc_ctt;
 	/* Specifies the value for EMC_CTT_DURATION */
-	u_int32_t emc_ctt_duration;
+	uint32_t emc_ctt_duration;
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PRE_REFRESH_REQ_CNT */
-	u_int32_t emc_prerefresh_req_cnt;
+	uint32_t emc_prerefresh_req_cnt;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TXSRDLL */
-	u_int32_t emc_txsr_dll;
+	uint32_t emc_txsr_dll;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TCKESR */
-	u_int32_t emc_tckesr;
+	uint32_t emc_tckesr;
 	/* Specifies the value for EMC_TPD */
-	u_int32_t emc_tpd;
+	uint32_t emc_tpd;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG6 */
-	u_int32_t emc_fbio_cfg6;
+	uint32_t emc_fbio_cfg6;
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 	/* Specifies the value for EMC_CFG_RSV */
-	u_int32_t emc_cfg_rsv;
+	uint32_t emc_cfg_rsv;
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the MP0 command to initialize mode registers */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the MP2 command to initialize mode registers */
-	u_int32_t emc_emrs2;
+	uint32_t emc_emrs2;
 	/* Specifies the MP3 command to initialize mode registers */
-	u_int32_t emc_emrs3;
+	uint32_t emc_emrs3;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at cold boot */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at cold boot */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 	/* Specifies the programming to LPDDR2 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw4;
+	uint32_t emc_mrw4;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at cold boot
 	 */
-	u_int32_t emc_mrw_extra;
+	uint32_t emc_mrw_extra;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at warm boot
 	 */
-	u_int32_t emc_warm_boot_mrw_extra;
+	uint32_t emc_warm_boot_mrw_extra;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * warm boot
 	 */
-	u_int32_t emc_warm_boot_extramode_reg_write_enable;
+	uint32_t emc_warm_boot_extramode_reg_write_enable;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * cold boot
 	 */
-	u_int32_t emc_extramode_reg_write_enable;
+	uint32_t emc_extramode_reg_write_enable;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 	/* Specifies the value for EMC_MRS_WAIT_CNT */
-	u_int32_t emc_mrs_wait_cnt;
+	uint32_t emc_mrs_wait_cnt;
 	/* Specifies the value for EMC_MRS_WAIT_CNT2 */
-	u_int32_t emc_mrs_wait_cnt2;
+	uint32_t emc_mrs_wait_cnt2;
 
 	/* EMC miscellaneous configurations */
 
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the pipe bypass controls */
-	u_int32_t emc_cfg_pipe;
+	uint32_t emc_cfg_pipe;
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 	/* Specifies the value for EMC_CMDQ */
-	u_int32_t emc_cmd_q;
+	uint32_t emc_cmd_q;
 	/* Specifies the value for EMC_MC2EMCQ */
-	u_int32_t emc_mc2emc_q;
+	uint32_t emc_mc2emc_q;
 	/* Specifies the value for EMC_DYN_SELF_REF_CONTROL */
-	u_int32_t emc_dyn_self_ref_control;
+	uint32_t emc_dyn_self_ref_control;
 
 	/* Specifies the value for MEM_INIT_DONE */
-	u_int32_t ahb_arbitration_xbar_ctrl_meminit_done;
+	uint32_t ahb_arbitration_xbar_ctrl_meminit_done;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL */
-	u_int32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll;
 	/* Specifies the value for EMC_CFG_DIG_DLL_PERIOD */
-	u_int32_t emc_cfg_dig_dll_period;
+	uint32_t emc_cfg_dig_dll_period;
 	/* Specifies the value of *DEV_SELECTN of various EMC registers */
-	u_int32_t emc_dev_select;
+	uint32_t emc_dev_select;
 
 	/* Specifies the value for EMC_SEL_DPD_CTRL */
-	u_int32_t emc_sel_dpd_ctrl;
+	uint32_t emc_sel_dpd_ctrl;
 
 	/* Pads trimmer delays */
 
 	/* Specifies the value for EMC_DLL_XFORM_DQS0 */
-	u_int32_t emc_dll_xform_dqs0;
+	uint32_t emc_dll_xform_dqs0;
 	/* Specifies the value for EMC_DLL_XFORM_DQS1 */
-	u_int32_t emc_dll_xform_dqs1;
+	uint32_t emc_dll_xform_dqs1;
 	/* Specifies the value for EMC_DLL_XFORM_DQS2 */
-	u_int32_t emc_dll_xform_dqs2;
+	uint32_t emc_dll_xform_dqs2;
 	/* Specifies the value for EMC_DLL_XFORM_DQS3 */
-	u_int32_t emc_dll_xform_dqs3;
+	uint32_t emc_dll_xform_dqs3;
 	/* Specifies the value for EMC_DLL_XFORM_DQS4 */
-	u_int32_t emc_dll_xform_dqs4;
+	uint32_t emc_dll_xform_dqs4;
 	/* Specifies the value for EMC_DLL_XFORM_DQS5 */
-	u_int32_t emc_dll_xform_dqs5;
+	uint32_t emc_dll_xform_dqs5;
 	/* Specifies the value for EMC_DLL_XFORM_DQS6 */
-	u_int32_t emc_dll_xform_dqs6;
+	uint32_t emc_dll_xform_dqs6;
 	/* Specifies the value for EMC_DLL_XFORM_DQS7 */
-	u_int32_t emc_dll_xform_dqs7;
+	uint32_t emc_dll_xform_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_DQS8 */
-	u_int32_t emc_dll_xform_dqs8;
+	uint32_t emc_dll_xform_dqs8;
 	/* Specifies the value for EMC_DLL_XFORM_DQS9 */
-	u_int32_t emc_dll_xform_dqs9;
+	uint32_t emc_dll_xform_dqs9;
 	/* Specifies the value for EMC_DLL_XFORM_DQS10 */
-	u_int32_t emc_dll_xform_dqs10;
+	uint32_t emc_dll_xform_dqs10;
 	/* Specifies the value for EMC_DLL_XFORM_DQS11 */
-	u_int32_t emc_dll_xform_dqs11;
+	uint32_t emc_dll_xform_dqs11;
 	/* Specifies the value for EMC_DLL_XFORM_DQS12 */
-	u_int32_t emc_dll_xform_dqs12;
+	uint32_t emc_dll_xform_dqs12;
 	/* Specifies the value for EMC_DLL_XFORM_DQS13 */
-	u_int32_t emc_dll_xform_dqs13;
+	uint32_t emc_dll_xform_dqs13;
 	/* Specifies the value for EMC_DLL_XFORM_DQS14 */
-	u_int32_t emc_dll_xform_dqs14;
+	uint32_t emc_dll_xform_dqs14;
 	/* Specifies the value for EMC_DLL_XFORM_DQS15 */
-	u_int32_t emc_dll_xform_dqs15;
+	uint32_t emc_dll_xform_dqs15;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE0 */
-	u_int32_t emc_dll_xform_quse0;
+	uint32_t emc_dll_xform_quse0;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE1 */
-	u_int32_t emc_dll_xform_quse1;
+	uint32_t emc_dll_xform_quse1;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE2 */
-	u_int32_t emc_dll_xform_quse2;
+	uint32_t emc_dll_xform_quse2;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE3 */
-	u_int32_t emc_dll_xform_quse3;
+	uint32_t emc_dll_xform_quse3;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE4 */
-	u_int32_t emc_dll_xform_quse4;
+	uint32_t emc_dll_xform_quse4;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE5 */
-	u_int32_t emc_dll_xform_quse5;
+	uint32_t emc_dll_xform_quse5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE6 */
-	u_int32_t emc_dll_xform_quse6;
+	uint32_t emc_dll_xform_quse6;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE7 */
-	u_int32_t emc_dll_xform_quse7;
+	uint32_t emc_dll_xform_quse7;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR0 */
-	u_int32_t emc_dll_xform_addr0;
+	uint32_t emc_dll_xform_addr0;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR1 */
-	u_int32_t emc_dll_xform_addr1;
+	uint32_t emc_dll_xform_addr1;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR2 */
-	u_int32_t emc_dll_xform_addr2;
+	uint32_t emc_dll_xform_addr2;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR3 */
-	u_int32_t emc_dll_xform_addr3;
+	uint32_t emc_dll_xform_addr3;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR4 */
-	u_int32_t emc_dll_xform_addr4;
+	uint32_t emc_dll_xform_addr4;
 	/* Specifies the value for EMC_DLL_XFORM_ADDR5 */
-	u_int32_t emc_dll_xform_addr5;
+	uint32_t emc_dll_xform_addr5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE8 */
-	u_int32_t emc_dll_xform_quse8;
+	uint32_t emc_dll_xform_quse8;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE9 */
-	u_int32_t emc_dll_xform_quse9;
+	uint32_t emc_dll_xform_quse9;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE10 */
-	u_int32_t emc_dll_xform_quse10;
+	uint32_t emc_dll_xform_quse10;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE11 */
-	u_int32_t emc_dll_xform_quse11;
+	uint32_t emc_dll_xform_quse11;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE12 */
-	u_int32_t emc_dll_xform_quse12;
+	uint32_t emc_dll_xform_quse12;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE13 */
-	u_int32_t emc_dll_xform_quse13;
+	uint32_t emc_dll_xform_quse13;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE14 */
-	u_int32_t emc_dll_xform_quse14;
+	uint32_t emc_dll_xform_quse14;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE15 */
-	u_int32_t emc_dll_xform_quse15;
+	uint32_t emc_dll_xform_quse15;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS0 */
-	u_int32_t emc_dli_trim_tx_dqs0;
+	uint32_t emc_dli_trim_tx_dqs0;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS1 */
-	u_int32_t emc_dli_trim_tx_dqs1;
+	uint32_t emc_dli_trim_tx_dqs1;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS2 */
-	u_int32_t emc_dli_trim_tx_dqs2;
+	uint32_t emc_dli_trim_tx_dqs2;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS3 */
-	u_int32_t emc_dli_trim_tx_dqs3;
+	uint32_t emc_dli_trim_tx_dqs3;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS4 */
-	u_int32_t emc_dli_trim_tx_dqs4;
+	uint32_t emc_dli_trim_tx_dqs4;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS5 */
-	u_int32_t emc_dli_trim_tx_dqs5;
+	uint32_t emc_dli_trim_tx_dqs5;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS6 */
-	u_int32_t emc_dli_trim_tx_dqs6;
+	uint32_t emc_dli_trim_tx_dqs6;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS7 */
-	u_int32_t emc_dli_trim_tx_dqs7;
+	uint32_t emc_dli_trim_tx_dqs7;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS8 */
-	u_int32_t emc_dli_trim_tx_dqs8;
+	uint32_t emc_dli_trim_tx_dqs8;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS9 */
-	u_int32_t emc_dli_trim_tx_dqs9;
+	uint32_t emc_dli_trim_tx_dqs9;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS10 */
-	u_int32_t emc_dli_trim_tx_dqs10;
+	uint32_t emc_dli_trim_tx_dqs10;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS11 */
-	u_int32_t emc_dli_trim_tx_dqs11;
+	uint32_t emc_dli_trim_tx_dqs11;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS12 */
-	u_int32_t emc_dli_trim_tx_dqs12;
+	uint32_t emc_dli_trim_tx_dqs12;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS13 */
-	u_int32_t emc_dli_trim_tx_dqs13;
+	uint32_t emc_dli_trim_tx_dqs13;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS14 */
-	u_int32_t emc_dli_trim_tx_dqs14;
+	uint32_t emc_dli_trim_tx_dqs14;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS15 */
-	u_int32_t emc_dli_trim_tx_dqs15;
+	uint32_t emc_dli_trim_tx_dqs15;
 	/* Specifies the value for EMC_DLL_XFORM_DQ0 */
-	u_int32_t emc_dll_xform_dq0;
+	uint32_t emc_dll_xform_dq0;
 	/* Specifies the value for EMC_DLL_XFORM_DQ1 */
-	u_int32_t emc_dll_xform_dq1;
+	uint32_t emc_dll_xform_dq1;
 	/* Specifies the value for EMC_DLL_XFORM_DQ2 */
-	u_int32_t emc_dll_xform_dq2;
+	uint32_t emc_dll_xform_dq2;
 	/* Specifies the value for EMC_DLL_XFORM_DQ3 */
-	u_int32_t emc_dll_xform_dq3;
+	uint32_t emc_dll_xform_dq3;
 	/* Specifies the value for EMC_DLL_XFORM_DQ4 */
-	u_int32_t emc_dll_xform_dq4;
+	uint32_t emc_dll_xform_dq4;
 	/* Specifies the value for EMC_DLL_XFORM_DQ5 */
-	u_int32_t emc_dll_xform_dq5;
+	uint32_t emc_dll_xform_dq5;
 	/* Specifies the value for EMC_DLL_XFORM_DQ6 */
-	u_int32_t emc_dll_xform_dq6;
+	uint32_t emc_dll_xform_dq6;
 	/* Specifies the value for EMC_DLL_XFORM_DQ7 */
-	u_int32_t emc_dll_xform_dq7;
+	uint32_t emc_dll_xform_dq7;
 
 	/*
 	 * Specifies the delay after asserting CKE pin during a WarmBoot0
 	 * sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_CTT_TERM_CTRL */
-	u_int32_t emc_ctt_term_ctrl;
+	uint32_t emc_ctt_term_ctrl;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_read;
+	uint32_t emc_odt_read;
 
 	/* Periodic ZQ calibration */
 
@@ -500,302 +500,302 @@ typedef struct nvboot_sdram_params_rec {
 	 * Specifies the value for EMC_ZCAL_INTERVAL
 	 * Value 0 disables ZQ calibration
 	 */
-	u_int32_t emc_zcal_interval;
+	uint32_t emc_zcal_interval;
 	/* Specifies the value for EMC_ZCAL_WAIT_CNT */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/* Specifies the value for EMC_ZCAL_MRW_CMD */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/* DRAM initialization sequence flow control */
 
 	/* Specifies the MRS command value for resetting DLL */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the command for ZQ initialization of device 0 */
-	u_int32_t emc_zcal_init_dev0;
+	uint32_t emc_zcal_init_dev0;
 	/* Specifies the command for ZQ initialization of device 1 */
-	u_int32_t emc_zcal_init_dev1;
+	uint32_t emc_zcal_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_zcal_init_wait;
+	uint32_t emc_zcal_init_wait;
 	/*
 	 * Specifies the enable for ZQ calibration at cold boot [bit 0]
 	 * and warm boot [bit 1]
 	 */
-	u_int32_t emc_zcal_warm_cold_boot_enables;
+	uint32_t emc_zcal_warm_cold_boot_enables;
 
 	/*
 	 * Specifies the MRW command to LPDDR2 for ZQ calibration
 	 * on warmboot
 	 */
 	/* Is issued to both devices separately */
-	u_int32_t emc_mrw_lpddr2zcal_warm_boot;
+	uint32_t emc_mrw_lpddr2zcal_warm_boot;
 	/*
 	 * Specifies the ZQ command to DDR3 for ZQ calibration on warmboot
 	 * Is issued to both devices separately
 	 */
-	u_int32_t emc_zqcal_ddr3_warm_boot;
+	uint32_t emc_zqcal_ddr3_warm_boot;
 	/*
 	 * Specifies the wait time for ZQ calibration on warmboot
 	 * (in microseconds)
 	 */
-	u_int32_t emc_zcal_warm_boot_wait;
+	uint32_t emc_zcal_warm_boot_wait;
 	/*
 	 * Specifies the enable for DRAM Mode Register programming
 	 * at warm boot
 	 */
-	u_int32_t emc_mrs_warm_boot_enable;
+	uint32_t emc_mrs_warm_boot_enable;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/* Specifies the extra MRS command to initialize mode registers */
-	u_int32_t emc_mrs_extra;
+	uint32_t emc_mrs_extra;
 	/* Specifies the extra MRS command at warm boot */
-	u_int32_t emc_warm_boot_mrs_extra;
+	uint32_t emc_warm_boot_mrs_extra;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 	/* Specifies the value for EMC_CLKEN_OVERRIDE */
-	u_int32_t emc_clken_override;
+	uint32_t emc_clken_override;
 	/* Specifies the value for MC_DIS_EXTRA_SNAP_LEVELS */
-	u_int32_t mc_dis_extra_snap_levels;
+	uint32_t mc_dis_extra_snap_levels;
 	/*
 	 * Specifies LOG2 of the extra refresh numbers after booting
 	 * Program 0 to disable
 	 */
-	u_int32_t emc_extra_refresh_num;
+	uint32_t emc_extra_refresh_num;
 	/* Specifies the master override for all EMC clocks */
-	u_int32_t emc_clken_override_allwarm_boot;
+	uint32_t emc_clken_override_allwarm_boot;
 	/* Specifies the master override for all MC clocks */
-	u_int32_t mc_clken_override_allwarm_boot;
+	uint32_t mc_clken_override_allwarm_boot;
 	/* Specifies digital dll period, choosing between 4 to 64 ms */
-	u_int32_t emc_cfg_dig_dll_period_warm_boot;
+	uint32_t emc_cfg_dig_dll_period_warm_boot;
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel;
+	uint32_t pmc_vddp_sel;
 	/* Specifies the wait time after programming PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel_wait;
+	uint32_t pmc_vddp_sel_wait;
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for PMC_DDR_CFG */
-	u_int32_t pmc_ddr_cfg;
+	uint32_t pmc_ddr_cfg;
 	/* Specifies the value for PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req;
+	uint32_t pmc_io_dpd3_req;
 	/* Specifies the wait time after programming PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req_wait;
+	uint32_t pmc_io_dpd3_req_wait;
 	/* Specifies the value for PMC_REG_SHORT */
-	u_int32_t pmc_reg_short;
+	uint32_t pmc_reg_short;
 	/* Specifies the value for PMC_NO_IOPOWER */
-	u_int32_t pmc_no_io_power;
+	uint32_t pmc_no_io_power;
 	/* Specifies the wait time after programming PMC_POR_DPD_CTRL */
-	u_int32_t pmc_por_dpd_ctrl_wait;
+	uint32_t pmc_por_dpd_ctrl_wait;
 	/* Specifies the value for EMC_XM2CMDPADCTRL */
-	u_int32_t emc_xm2cmd_pad_ctrl;
+	uint32_t emc_xm2cmd_pad_ctrl;
 	/* Specifies the value for EMC_XM2CMDPADCTRL2 */
-	u_int32_t emc_xm2cmd_pad_ctrl2;
+	uint32_t emc_xm2cmd_pad_ctrl2;
 	/* Specifies the value for EMC_XM2CMDPADCTRL3 */
-	u_int32_t emc_xm2cmd_pad_ctrl3;
+	uint32_t emc_xm2cmd_pad_ctrl3;
 	/* Specifies the value for EMC_XM2CMDPADCTRL4 */
-	u_int32_t emc_xm2cmd_pad_ctrl4;
+	uint32_t emc_xm2cmd_pad_ctrl4;
 	/* Specifies the value for EMC_XM2CMDPADCTRL5 */
-	u_int32_t emc_xm2cmd_pad_ctrl5;
+	uint32_t emc_xm2cmd_pad_ctrl5;
 	/* Specifies the value for EMC_XM2DQSPADCTRL */
-	u_int32_t emc_xm2dqs_pad_ctrl;
+	uint32_t emc_xm2dqs_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQSPADCTRL2 */
-	u_int32_t emc_xm2dqs_pad_ctrl2;
+	uint32_t emc_xm2dqs_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQSPADCTRL3 */
-	u_int32_t emc_xm2dqs_pad_ctrl3;
+	uint32_t emc_xm2dqs_pad_ctrl3;
 	/* Specifies the value for EMC_XM2DQSPADCTRL4 */
-	u_int32_t emc_xm2dqs_pad_ctrl4;
+	uint32_t emc_xm2dqs_pad_ctrl4;
 	/* Specifies the value for EMC_XM2DQSPADCTRL5 */
-	u_int32_t emc_xm2dqs_pad_ctrl5;
+	uint32_t emc_xm2dqs_pad_ctrl5;
 	/* Specifies the value for EMC_XM2DQSPADCTRL6 */
-	u_int32_t emc_xm2dqs_pad_ctrl6;
+	uint32_t emc_xm2dqs_pad_ctrl6;
 	/* Specifies the value for EMC_XM2DQPADCTRL */
-	u_int32_t emc_xm2dq_pad_ctrl;
+	uint32_t emc_xm2dq_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQPADCTRL2 */
-	u_int32_t emc_xm2dq_pad_ctrl2;
+	uint32_t emc_xm2dq_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQPADCTRL3 */
-	u_int32_t emc_xm2dq_pad_ctrl3;
+	uint32_t emc_xm2dq_pad_ctrl3;
 	/* Specifies the value for EMC_XM2CLKPADCTRL */
-	u_int32_t emc_xm2clk_pad_ctrl;
+	uint32_t emc_xm2clk_pad_ctrl;
 	/* Specifies the value for EMC_XM2CLKPADCTRL2 */
-	u_int32_t emc_xm2clk_pad_ctrl2;
+	uint32_t emc_xm2clk_pad_ctrl2;
 	/* Specifies the value for EMC_XM2COMPPADCTRL */
-	u_int32_t emc_xm2comp_pad_ctrl;
+	uint32_t emc_xm2comp_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL */
-	u_int32_t emc_xm2vttgen_pad_ctrl;
+	uint32_t emc_xm2vttgen_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL2 */
-	u_int32_t emc_xm2vttgen_pad_ctrl2;
+	uint32_t emc_xm2vttgen_pad_ctrl2;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL3 */
-	u_int32_t emc_xm2vttgen_pad_ctrl3;
+	uint32_t emc_xm2vttgen_pad_ctrl3;
 	/* Specifies the value for EMC_ACPD_CONTROL */
-	u_int32_t emc_acpd_control;
+	uint32_t emc_acpd_control;
 
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE_CFG */
-	u_int32_t emc_swizzle_rank0_byte_cfg;
+	uint32_t emc_swizzle_rank0_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
-	u_int32_t emc_swizzle_rank0_byte0;
+	uint32_t emc_swizzle_rank0_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
-	u_int32_t emc_swizzle_rank0_byte1;
+	uint32_t emc_swizzle_rank0_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE2 */
-	u_int32_t emc_swizzle_rank0_byte2;
+	uint32_t emc_swizzle_rank0_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
-	u_int32_t emc_swizzle_rank0_byte3;
+	uint32_t emc_swizzle_rank0_byte3;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE_CFG */
-	u_int32_t emc_swizzle_rank1_byte_cfg;
+	uint32_t emc_swizzle_rank1_byte_cfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
-	u_int32_t emc_swizzle_rank1_byte0;
+	uint32_t emc_swizzle_rank1_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */
-	u_int32_t emc_swizzle_rank1_byte1;
+	uint32_t emc_swizzle_rank1_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE2 */
-	u_int32_t emc_swizzle_rank1_byte2;
+	uint32_t emc_swizzle_rank1_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE3 */
-	u_int32_t emc_swizzle_rank1_byte3;
+	uint32_t emc_swizzle_rank1_byte3;
 
 	/* Specifies the value for EMC_DSR_VTTGEN_DRV */
-	u_int32_t emc_dsr_vttgen_drv;
+	uint32_t emc_dsr_vttgen_drv;
 
 	/* Specifies the value for EMC_TXDSRVTTGEN */
-	u_int32_t emc_txdsrvttgen;
+	uint32_t emc_txdsrvttgen;
 	/* Specifies the value for EMC_BGBIAS_CTL */
-	u_int32_t emc_bgbias_ctl0;
+	uint32_t emc_bgbias_ctl0;
 
 	/* DRAM size information */
 
 	/* Specifies the value for MC_EMEM_ADR_CFG */
-	u_int32_t mc_emem_adr_cfg;
+	uint32_t mc_emem_adr_cfg;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV0 */
-	u_int32_t mc_emem_adr_cfg_dev0;
+	uint32_t mc_emem_adr_cfg_dev0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV1 */
-	u_int32_t mc_emem_adr_cfg_dev1;
+	uint32_t mc_emem_adr_cfg_dev1;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG0 */
-	u_int32_t mc_emem_adr_cfg_bank_mask0;
+	uint32_t mc_emem_adr_cfg_bank_mask0;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG1 */
-	u_int32_t mc_emem_adr_cfg_bank_mask1;
+	uint32_t mc_emem_adr_cfg_bank_mask1;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG2 */
-	u_int32_t mc_emem_adr_cfg_bank_mask2;
+	uint32_t mc_emem_adr_cfg_bank_mask2;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG3 */
-	u_int32_t mc_emem_adr_cfg_bank_swizzle3;
+	uint32_t mc_emem_adr_cfg_bank_swizzle3;
 
 	/*
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/* MC arbitration configuration */
 
 	/* Specifies the value for MC_EMEM_ARB_CFG */
-	u_int32_t mc_emem_arb_cfg;
+	uint32_t mc_emem_arb_cfg;
 	/* Specifies the value for MC_EMEM_ARB_OUTSTANDING_REQ */
-	u_int32_t mc_emem_arb_outstanding_req;
+	uint32_t mc_emem_arb_outstanding_req;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RCD */
-	u_int32_t mc_emem_arb_timing_rcd;
+	uint32_t mc_emem_arb_timing_rcd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RP */
-	u_int32_t mc_emem_arb_timing_rp;
+	uint32_t mc_emem_arb_timing_rp;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RC */
-	u_int32_t mc_emem_arb_timing_rc;
+	uint32_t mc_emem_arb_timing_rc;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAS */
-	u_int32_t mc_emem_arb_timing_ras;
+	uint32_t mc_emem_arb_timing_ras;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_FAW */
-	u_int32_t mc_emem_arb_timing_faw;
+	uint32_t mc_emem_arb_timing_faw;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RRD */
-	u_int32_t mc_emem_arb_timing_rrd;
+	uint32_t mc_emem_arb_timing_rrd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAP2PRE */
-	u_int32_t mc_emem_arb_timing_rap2pre;
+	uint32_t mc_emem_arb_timing_rap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_WAP2PRE */
-	u_int32_t mc_emem_arb_timing_wap2pre;
+	uint32_t mc_emem_arb_timing_wap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2R */
-	u_int32_t mc_emem_arb_timing_r2r;
+	uint32_t mc_emem_arb_timing_r2r;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2W */
-	u_int32_t mc_emem_arb_timing_w2w;
+	uint32_t mc_emem_arb_timing_w2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2W */
-	u_int32_t mc_emem_arb_timing_r2w;
+	uint32_t mc_emem_arb_timing_r2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2R */
-	u_int32_t mc_emem_arb_timing_w2r;
+	uint32_t mc_emem_arb_timing_w2r;
 	/* Specifies the value for MC_EMEM_ARB_DA_TURNS */
-	u_int32_t mc_emem_arb_da_turns;
+	uint32_t mc_emem_arb_da_turns;
 	/* Specifies the value for MC_EMEM_ARB_DA_COVERS */
-	u_int32_t mc_emem_arb_da_covers;
+	uint32_t mc_emem_arb_da_covers;
 	/* Specifies the value for MC_EMEM_ARB_MISC0 */
-	u_int32_t mc_emem_arb_misc0;
+	uint32_t mc_emem_arb_misc0;
 	/* Specifies the value for MC_EMEM_ARB_MISC1 */
-	u_int32_t mc_emem_arb_misc1;
+	uint32_t mc_emem_arb_misc1;
 	/* Specifies the value for MC_EMEM_ARB_RING1_THROTTLE */
-	u_int32_t mc_emem_arb_ring1_throttle;
+	uint32_t mc_emem_arb_ring1_throttle;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE */
-	u_int32_t mc_emem_arb_override;
+	uint32_t mc_emem_arb_override;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE_1 */
-	u_int32_t mc_emem_arb_override1;
+	uint32_t mc_emem_arb_override1;
 	/* Specifies the value for MC_EMEM_ARB_RSV */
-	u_int32_t mc_emem_arb_rsv;
+	uint32_t mc_emem_arb_rsv;
 
 	/* Specifies the value for MC_CLKEN_OVERRIDE */
-	u_int32_t mc_clken_override;
+	uint32_t mc_clken_override;
 
 	/* Specifies the value for MC_STAT_CONTROL */
-	u_int32_t mc_stat_control;
+	uint32_t mc_stat_control;
 	/* Specifies the value for MC_DISPLAY_SNAP_RING */
-	u_int32_t mc_display_snap_ring;
+	uint32_t mc_display_snap_ring;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM */
-	u_int32_t mc_video_protect_bom;
+	uint32_t mc_video_protect_bom;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM_ADR_HI */
-	u_int32_t mc_video_protect_bom_adr_hi;
+	uint32_t mc_video_protect_bom_adr_hi;
 	/* Specifies the value for MC_VIDEO_PROTECT_SIZE_MB */
-	u_int32_t mc_video_protect_size_mb;
+	uint32_t mc_video_protect_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE */
-	u_int32_t mc_video_protect_vpr_override;
+	uint32_t mc_video_protect_vpr_override;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE1 */
-	u_int32_t mc_video_protect_vpr_override1;
+	uint32_t mc_video_protect_vpr_override1;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_0 */
-	u_int32_t mc_video_protect_gpu_override0;
+	uint32_t mc_video_protect_gpu_override0;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_1 */
-	u_int32_t mc_video_protect_gpu_override1;
+	uint32_t mc_video_protect_gpu_override1;
 	/* Specifies the value for MC_SEC_CARVEOUT_BOM */
-	u_int32_t mc_sec_carveout_bom;
+	uint32_t mc_sec_carveout_bom;
 	/* Specifies the value for MC_SEC_CARVEOUT_ADR_HI */
-	u_int32_t mc_sec_carveout_adr_hi;
+	uint32_t mc_sec_carveout_adr_hi;
 	/* Specifies the value for MC_SEC_CARVEOUT_SIZE_MB */
-	u_int32_t mc_sec_carveout_size_mb;
+	uint32_t mc_sec_carveout_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_REG_CTRL.VIDEO_PROTECT_WRITE_ACCESS */
-	u_int32_t mc_video_protect_write_access;
+	uint32_t mc_video_protect_write_access;
 	/* Specifies the value for MC_SEC_CARVEOUT_REG_CTRL.SEC_CARVEOUT_WRITE_ACCESS */
-	u_int32_t mc_sec_carveout_protect_write_access;
+	uint32_t mc_sec_carveout_protect_write_access;
 
 	/* Specifies enable for CA training */
-	u_int32_t emc_ca_training_enable;
+	uint32_t emc_ca_training_enable;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL1 */
-	u_int32_t emc_ca_training_timing_cntl1;
+	uint32_t emc_ca_training_timing_cntl1;
 	/* Specifies the value for EMC_CA_TRAINING_TIMING_CNTRL2 */
-	u_int32_t emc_ca_training_timing_cntl2;
+	uint32_t emc_ca_training_timing_cntl2;
 	/* Set if bit 6 select is greater than bit 7 select; uses aremc.spec packet SWIZZLE_BIT6_GT_BIT7 */
-	u_int32_t swizzle_rank_byte_encode;
+	uint32_t swizzle_rank_byte_encode;
 	/* Specifies enable and offset for patched boot rom write */
-	u_int32_t boot_rom_patch_control;
+	uint32_t boot_rom_patch_control;
 	/* Specifies data for patched boot rom write */
-	u_int32_t boot_rom_patch_data;
+	uint32_t boot_rom_patch_data;
 	/* Specifies the value for MC_MTS_CARVEOUT_BOM */
-	u_int32_t mc_mts_carveout_bom;
+	uint32_t mc_mts_carveout_bom;
 	/* Specifies the value for MC_MTS_CARVEOUT_ADR_HI */
-	u_int32_t mc_mts_carveout_adr_hi;
+	uint32_t mc_mts_carveout_adr_hi;
 	/* Specifies the value for MC_MTS_CARVEOUT_SIZE_MB */
-	u_int32_t mc_mts_carveout_size_mb;
+	uint32_t mc_mts_carveout_size_mb;
 	/* Specifies the value for MC_MTS_CARVEOUT_REG_CTRL */
-	u_int32_t mc_mts_carveout_reg_ctrl;
+	uint32_t mc_mts_carveout_reg_ctrl;
 
 	/* End of generated code by warmboot_code_gen */
 } nvboot_sdram_params;

--- a/src/t20/nvbctlib_t20.c
+++ b/src/t20/nvbctlib_t20.c
@@ -59,22 +59,22 @@ case token_bl_##x:\
 #define CASE_GET_NVU32(id) \
 case token_##id:\
 	if (bct == NULL) return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -113,9 +113,9 @@ parse_token t20_root_token_list[] = {
 
 int
 t20_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -153,9 +153,9 @@ t20_set_dev_param(build_image_context *context,
 
 int
 t20_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -191,9 +191,9 @@ t20_get_dev_param(build_image_context *context,
 
 int
 t20_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -315,9 +315,9 @@ t20_set_sdram_param(build_image_context *context,
 
 int
 t20_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -435,10 +435,10 @@ t20_get_sdram_param(build_image_context *context,
 }
 
 int
-t20_getbl_param(u_int32_t set,
+t20_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -470,10 +470,10 @@ t20_getbl_param(u_int32_t set,
 }
 
 int
-t20_setbl_param(u_int32_t set,
+t20_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -505,7 +505,7 @@ t20_setbl_param(u_int32_t set,
 }
 
 int
-t20_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t20_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -533,13 +533,13 @@ t20_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	/*
@@ -550,25 +550,25 @@ t20_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	CASE_GET_CONST(reserved_size,     NVBOOT_BCT_RESERVED_SIZE);
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size   of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = sizeof(nvboot_config_table) - sizeof(nvboot_hash);
+		*((uint32_t *)data) = sizeof(nvboot_config_table) - sizeof(nvboot_hash);
 	break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -596,7 +596,7 @@ t20_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 }
 
 int
-t20_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t20_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -625,9 +625,9 @@ t20_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t20_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t  length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t  length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -663,7 +663,7 @@ int t20_bct_token_supported(parse_token token)
 
 void t20_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t20/nvboot_bct_t20.h
+++ b/src/t20/nvboot_bct_t20.h
@@ -97,7 +97,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /* Defines the params that can be configured for NAND devices. */
@@ -107,19 +107,19 @@ typedef struct nvboot_nand_params_rec {
 	 * If it is set to 18, then clock source to Nand controller is
 	 * 432 / 18 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the value to be programmed to Nand Timing Register 1 */
-	u_int32_t nand_timing;
+	uint32_t nand_timing;
 
 	/* Specifies the value to be programmed to Nand Timing Register 2 */
-	u_int32_t nand_timing2;
+	uint32_t nand_timing2;
 
 	/* Specifies the block size in log2 bytes */
-	u_int8_t block_size_log2;
+	uint8_t block_size_log2;
 
 	/* Specifies the page size in log2 bytes */
-	u_int8_t page_size_log2;
+	uint8_t page_size_log2;
 } nvboot_nand_params;
 
 /* Defines various data widths supported. */
@@ -152,7 +152,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 432MHz.  If it is set to 18, then the SDMMC
 	 * controller runs at 432/18 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -163,7 +163,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 } nvboot_sdmmc_params;
 
 typedef enum {
@@ -203,14 +203,14 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 } nvboot_spiflash_params;
 
 /**
@@ -257,13 +257,13 @@ typedef enum {
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 	nvboot_hash crypto_hash;
 } nv_bootloader_info;
 
@@ -271,10 +271,10 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 } nvboot_badblock_table;
 
 /**
@@ -288,19 +288,19 @@ typedef struct nvboot_badblock_table_rec {
 typedef struct nvboot_config_table_rec {
 	nvboot_hash crypto_hash;
 	nvboot_hash random_aes_blk;
-	u_int32_t boot_data_version;
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;
+	uint32_t num_sdram_sets;
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS];
 	nvboot_badblock_table badblock_table;
-	u_int32_t bootloader_used;
+	uint32_t bootloader_used;
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
 
 	/*
 	 * ODMDATA is stored in the BCT in IRAM by the BootROM.
@@ -308,9 +308,9 @@ typedef struct nvboot_config_table_rec {
 	 * on T20 and T30 BCTs, which are locked down. If this changes
 	 * in new chips, we can revisit this algorithm.
 	 */
-	u_int32_t odm_data;
-	u_int32_t reserved1;
-	u_int8_t enable_fail_back;
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint32_t odm_data;
+	uint32_t reserved1;
+	uint8_t enable_fail_back;
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T20_H */

--- a/src/t20/nvboot_sdram_param_t20.h
+++ b/src/t20/nvboot_sdram_param_t20.h
@@ -57,166 +57,166 @@ typedef struct nvboot_sdram_params_rec {
 	nvboot_memory_type memory_type;
 
 	/* Specifies the CPCON value for PllM */
-	u_int32_t pllm_charge_pump_setup_ctrl;
+	uint32_t pllm_charge_pump_setup_ctrl;
 	/* Specifies the LPCON value for PllM */
-	u_int32_t pllm_loop_filter_setup_ctrl;
+	uint32_t pllm_loop_filter_setup_ctrl;
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the P value for PllM */
-	u_int32_t pllm_post_divider;
+	uint32_t pllm_post_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 
 	/* Specifies the divider for the EMC Clock Source */
-	u_int32_t emc_clock_divider;
+	uint32_t emc_clock_divider;
 
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/**
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 	/**
 	 * Specifies the time for the calibration to
 	 * stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
 	/**
 	 * Specifies the time to wait after pin programming (in microseconds)
 	 * Dram vendors require at least 200us.
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_QRST */
-	u_int32_t emc_qrst;
+	uint32_t emc_qrst;
 	/* Specifies the value for EMC_QSAFE */
-	u_int32_t emc_qsafe;
+	uint32_t emc_qsafe;
 	/* Specifies the value for EMC_RDV */
-	u_int32_t emc_rdv;
+	uint32_t emc_rdv;
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 	/* Specifies the value for EMC_QUSE_EXTRA */
-	u_int32_t emc_quse_extra;
+	uint32_t emc_quse_extra;
 
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG1 */
-	u_int32_t emc_fbio_cfg1;
+	uint32_t emc_fbio_cfg1;
 	/* Specifies the value for EMC_FBIO_DQSIB_DLY */
-	u_int32_t emc_fbio_dqsib_dly;
+	uint32_t emc_fbio_dqsib_dly;
 	/* Specifies the value for EMC_FBIO_DQSIB_DLY_MSB */
-	u_int32_t emc_fbio_dqsib_dly_msb;
+	uint32_t emc_fbio_dqsib_dly_msb;
 	/* Specifies the value for EMC_FBIO_QUSE_DLY */
-	u_int32_t emc_fbio_quse_dly;
+	uint32_t emc_fbio_quse_dly;
 	/* Specifies the value for EMC_FBIO_QUSE_DLY_MSB */
-	u_int32_t emc_fbio_quse_dly_msb;
+	uint32_t emc_fbio_quse_dly_msb;
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG6 */
-	u_int32_t emc_fbio_cfg6;
+	uint32_t emc_fbio_cfg6;
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the value for EMC_EMRS */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the first  of a sequence of three values for EMC_MRW */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the second of a sequence of three values for EMC_MRW */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the third  of a sequence of three values for EMC_MRW */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 
 	/**
 	 * Specifies the value for EMC_ADR_CFG
 	 * The same value is also used for MC_EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 	/* Specifies the value for EMC_ADR_CFG_1 */
-	u_int32_t emc_adr_cfg1;
+	uint32_t emc_adr_cfg1;
 
 	/**
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 * EMEM_SIZE_KB must be <= (Device size in KB * Number of Devices)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/**
 	 * Specifies the value for MC_LOWLATENCY_CONFIG
@@ -224,139 +224,139 @@ typedef struct nvboot_sdram_params_rec {
 	 * mode. If so, turn off this bit to get the correct low-latency path
 	 * behavior. Reset is ENABLED.
 	 */
-	u_int32_t mc_lowlatency_config;
+	uint32_t mc_lowlatency_config;
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 
 	/*
 	 * Specifies the value for AHB_ARBITRATION_XBAR_CTRL.
 	 * This is used to set the Memory Inid done
 	 */
-	u_int32_t ahb_arbitration_xbar_ctrl;
+	uint32_t ahb_arbitration_xbar_ctrl;
 
 	/*
 	 * Specifies the value for EMC_CFG_DIG_DLL
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll;
 	/* Specifies the value for EMC_DLL_XFORM_DQS */
-	u_int32_t emc_dll_xform_dqs;
+	uint32_t emc_dll_xform_dqs;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE */
-	u_int32_t emc_dll_xform_quse;
+	uint32_t emc_dll_xform_quse;
 
 	/*
 	 * Specifies the delay after prgramming the PIN/NOP register during a
 	 * WarmBoot0 sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_CTT_TERM_CTRL */
-	u_int32_t emc_ctt_term_ctrl;
+	uint32_t emc_ctt_term_ctrl;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_read;
+	uint32_t emc_odt_read;
 
 	/*
 	 * Specifies the value for EMC_ZCAL_REF_CNT
 	 * Only meaningful for LPDDR2. Set to 0 for all other memory types.
 	 */
-	u_int32_t emc_zcal_ref_cnt;
+	uint32_t emc_zcal_ref_cnt;
 	/*
 	 * Specifies the value for EMC_ZCAL_WAIT_CNT
 	 * Only meaningful for LPDDR2. Set to 0 for all other memory types.
 	 */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/*
 	 * Specifies the value for EMC_ZCAL_MRW_CMD
 	 * Only meaningful for LPDDR2. Set to 0 for all other memory types.
 	 */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/*
 	 * Specifies the MRS command value for initilizing
 	 * the mode register.
 	 */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the MRW command for ZQ initialization of device 0 */
-	u_int32_t emc_mrw_zq_init_dev0;
+	uint32_t emc_mrw_zq_init_dev0;
 	/* Specifies the MRW command for ZQ initialization of device 1 */
-	u_int32_t emc_mrw_zq_init_dev1;
+	uint32_t emc_mrw_zq_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_mrw_zq_init_wait;
+	uint32_t emc_mrw_zq_init_wait;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * (in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/*
 	 * Specifies the first of two EMRS commands to initialize mode
 	 * registers
 	 */
-	u_int32_t emc_emrs_emr2;
+	uint32_t emc_emrs_emr2;
 	/*
 	 * Specifies the second of two EMRS commands to initialize mode
 	 * registers
 	 */
-	u_int32_t emc_emrs_emr3;
+	uint32_t emc_emrs_emr3;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 
 
 	/* Clock trimmers */
 
 	/* Specifies the value for EMC_CFG_CLKTRIM_0 */
-	u_int32_t emc_cfg_clktrim0;
+	uint32_t emc_cfg_clktrim0;
 	/* Specifies the value for EMC_CFG_CLKTRIM_1 */
-	u_int32_t emc_cfg_clktrim1;
+	uint32_t emc_cfg_clktrim1;
 	/* Specifies the value for EMC_CFG_CLKTRIM_2 */
-	u_int32_t emc_cfg_clktrim2;
+	uint32_t emc_cfg_clktrim2;
 
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for APB_MISC_GP_XM2CFGAPADCTRL */
-	u_int32_t apb_misc_gp_xm2cfga_pad_ctrl;
+	uint32_t apb_misc_gp_xm2cfga_pad_ctrl;
 	/* Specifies the value for APB_MISC_GP_XM2CFGCPADCTRL */
-	u_int32_t apb_misc_gp_xm2cfgc_pad_ctrl;
+	uint32_t apb_misc_gp_xm2cfgc_pad_ctrl;
 	/* Specifies the value for APB_MISC_GP_XM2CFGCPADCTRL2 */
-	u_int32_t apb_misc_gp_xm2cfgc_pad_ctrl2;
+	uint32_t apb_misc_gp_xm2cfgc_pad_ctrl2;
 	/* Specifies the value for APB_MISC_GP_XM2CFGDPADCTRL */
-	u_int32_t apb_misc_gp_xm2cfgd_pad_ctrl;
+	uint32_t apb_misc_gp_xm2cfgd_pad_ctrl;
 	/* Specifies the value for APB_MISC_GP_XM2CFGDPADCTRL2 */
-	u_int32_t apb_misc_gp_xm2cfgd_pad_ctrl2;
+	uint32_t apb_misc_gp_xm2cfgd_pad_ctrl2;
 	/* Specifies the value for APB_MISC_GP_XM2CLKCFGPADCTRL */
-	u_int32_t apb_misc_gp_xm2clkcfg_Pad_ctrl;
+	uint32_t apb_misc_gp_xm2clkcfg_Pad_ctrl;
 	/* Specifies the value for APB_MISC_GP_XM2COMPPADCTRL */
-	u_int32_t apb_misc_gp_xm2comp_pad_ctrl;
+	uint32_t apb_misc_gp_xm2comp_pad_ctrl;
 	/* Specifies the value for APB_MISC_GP_XM2VTTGENPADCTRL */
-	u_int32_t apb_misc_gp_xm2vttgen_pad_ctrl;
+	uint32_t apb_misc_gp_xm2vttgen_pad_ctrl;
 
 	/*
 	 * Specifies storage for arbitration configuration registers
 	 * Data passed through to the Bootloader but not used by
 	 * the Boot ROM
 	 */
-	u_int32_t arbitration_config[NVBOOT_BCT_SDRAM_ARB_CONFIG_WORDS];
+	uint32_t arbitration_config[NVBOOT_BCT_SDRAM_ARB_CONFIG_WORDS];
 } nvboot_sdram_params;
 
 #endif /* #ifndef INCLUDED_NVBOOT_SDRAM_PARAM_T20_H */

--- a/src/t210/nvbctlib_t210.c
+++ b/src/t210/nvbctlib_t210.c
@@ -60,22 +60,22 @@ case token_bl_##x:\
 case token_##id:\
 	if (bct == NULL) \
 		return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -123,9 +123,9 @@ parse_token t210_root_token_list[] = {
 
 int
 t210_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -159,9 +159,9 @@ t210_set_dev_param(build_image_context *context,
 
 int
 t210_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -193,9 +193,9 @@ t210_get_dev_param(build_image_context *context,
 
 int
 t210_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -1100,9 +1100,9 @@ t210_get_sdram_param(build_image_context *context,
 
 int
 t210_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -2009,10 +2009,10 @@ t210_set_sdram_param(build_image_context *context,
 }
 
 int
-t210_getbl_param(u_int32_t set,
+t210_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -2037,8 +2037,8 @@ t210_getbl_param(u_int32_t set,
 		break;
 
 	case token_rsa_pss_sig_bl:
-		reverse_byte_order((u_int8_t *)data,
-			(const u_int8_t *)&bct_ptr->bootloader[set].signature.rsa_pss_sig,
+		reverse_byte_order((uint8_t *)data,
+			(const uint8_t *)&bct_ptr->bootloader[set].signature.rsa_pss_sig,
 			sizeof(nvboot_rsa_pss_sig));
 		break;
 
@@ -2050,10 +2050,10 @@ t210_getbl_param(u_int32_t set,
 }
 
 int
-t210_setbl_param(u_int32_t set,
+t210_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -2085,7 +2085,7 @@ t210_setbl_param(u_int32_t set,
 }
 
 int
-t210_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t210_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -2114,13 +2114,13 @@ t210_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	/*
@@ -2139,37 +2139,37 @@ t210_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_rsa_key_modulus:
-		reverse_byte_order(data, (const u_int8_t *)&bct_ptr->key,
+		reverse_byte_order(data, (const uint8_t *)&bct_ptr->key,
 				sizeof(nvboot_rsa_key_modulus));
 		break;
 
 	case token_rsa_pss_sig_bct:
 		reverse_byte_order(data,
-			(const u_int8_t *)&bct_ptr->signature.rsa_pss_sig,
+			(const uint8_t *)&bct_ptr->signature.rsa_pss_sig,
 			sizeof(nvboot_rsa_pss_sig));
 		break;
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)bct_ptr + sizeof(nvboot_config_table)
-				- (u_int8_t *)&(bct_ptr->random_aes_blk);
+		*((uint32_t *)data) = (uint8_t *)bct_ptr + sizeof(nvboot_config_table)
+				- (uint8_t *)&(bct_ptr->random_aes_blk);
 		break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -2218,7 +2218,7 @@ t210_bct_get_value_size(parse_token id)
 }
 
 int
-t210_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t210_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -2243,7 +2243,7 @@ t210_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 		break;
 
 	case token_rsa_key_modulus:
-		reverse_byte_order((u_int8_t *)&bct_ptr->key, data,
+		reverse_byte_order((uint8_t *)&bct_ptr->key, data,
 					sizeof(nvboot_rsa_key_modulus));
 		break;
 
@@ -2253,12 +2253,12 @@ t210_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 		 * of bootloader being built in.
 		 */
 		reverse_byte_order(
-			(u_int8_t *)&bct_ptr->bootloader[0].signature.rsa_pss_sig,
+			(uint8_t *)&bct_ptr->bootloader[0].signature.rsa_pss_sig,
 			data, sizeof(nvboot_rsa_pss_sig));
 		break;
 
 	case token_rsa_pss_sig_bct:
-		reverse_byte_order((u_int8_t *)&bct_ptr->signature.rsa_pss_sig,
+		reverse_byte_order((uint8_t *)&bct_ptr->signature.rsa_pss_sig,
 			data, sizeof(nvboot_rsa_pss_sig));
 		break;
 
@@ -2271,9 +2271,9 @@ t210_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t210_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -2313,7 +2313,7 @@ int t210_bct_token_supported(parse_token token)
 
 void t210_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t210/nvboot_bct_t210.h
+++ b/src/t210/nvboot_bct_t210.h
@@ -110,7 +110,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /*
@@ -119,7 +119,7 @@ typedef struct nvboot_hash_rec {
  */
 typedef struct nvboot_rsa_key_modulus_rec {
 	/* The modulus size is 2048-bits. */
-	u_int32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t modulus[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_key_modulus;
 
 typedef struct nvboot_rsa_pss_sig_rec {
@@ -128,7 +128,7 @@ typedef struct nvboot_rsa_pss_sig_rec {
 	 * length in octets of the RSA modulus.
 	 * In our case, it's 2048-bits.
 	 */
-	u_int32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
+	uint32_t signature[NVBOOT_SE_RSA_MODULUS_LENGTH_BITS / 8 / 4];
 } nvboot_rsa_pss_sig;
 
 typedef struct nvboot_object_signature_rec {
@@ -146,10 +146,10 @@ typedef struct nvboot_object_signature_rec {
 } nvboot_object_signature;
 
 typedef struct nvboot_ecid_rec {
-	u_int32_t	ecid_0;
-	u_int32_t	ecid_1;
-	u_int32_t	ecid_2;
-	u_int32_t	ecid_3;
+	uint32_t	ecid_0;
+	uint32_t	ecid_1;
+	uint32_t	ecid_2;
+	uint32_t	ecid_3;
 } nvboot_ecid;
 
 /* Defines various data widths supported. */
@@ -186,7 +186,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 216MHz.  If it is set to 9, then the SDMMC
 	 * controller runs at 216/9 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -197,10 +197,10 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 
 	/* Specifies the max page size supported by driver */
-	u_int8_t multi_page_support;
+	uint8_t multi_page_support;
 } nvboot_sdmmc_params;
 
 typedef enum {
@@ -221,7 +221,7 @@ typedef struct nvboot_spiflash_params_rec {
 	/**
 	 * Specifies the clock source to use.
 	 */
-	u_int32_t clock_source;
+	uint32_t clock_source;
 
 	/**
 	 * Specifes the clock divider to use.
@@ -233,24 +233,24 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 
 	/* 0 = 2k page size, 1 = 16K page size */
-	u_int8_t page_size_2k_or_16k;
+	uint8_t page_size_2k_or_16k;
 } nvboot_spiflash_params;
 
 /**
 * Defines the union of the parameters required by each device.
 */
 typedef union {
-	u_int8_t size[64];
+	uint8_t size[64];
 	/* Specifies optimized parameters for eMMC and eSD */
 	nvboot_sdmmc_params sdmmc_params;
 	/* Specifies optimized parameters for SPI NOR */
@@ -286,13 +286,13 @@ typedef enum {
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 
 	/* Specifies the AES-CMAC MAC or RSASSA-PSS signature of the BL. */
 	nvboot_object_signature signature;
@@ -302,15 +302,15 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 	/*
 	 * Add a reserved field as padding to make the bad block table structure
 	 * a multiple of 16 bytes (AES block size).
 	 */
-	u_int8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
+	uint8_t reserved[NVBOOT_BAD_BLOCK_TABLE_PADDING];
 } nvboot_badblock_table;
 
 enum {NVBOOT_SE_AES_KEY256_LENGTH_BYTES = 32};
@@ -335,35 +335,35 @@ typedef struct nvboot_config_table_rec {
 	 * This field must match SecProvisioningKeyNum_Secure to be a valid
 	 * BCT for use in the Factory Secure Provisioning mode.
 	 */
-	u_int32_t secure_provisioning_key_number_insecure;	/* 420 */
+	uint32_t secure_provisioning_key_number_insecure;	/* 420 */
 
 	/**
 	 * A 256-bit AES key encrypted by a reserved 256-bit AES "key wrap"
 	 * key. Only used in Factory Secure Provisioning mode.
 	 */
-	u_int8_t aes_key[NVBOOT_SE_AES_KEY256_LENGTH_BYTES];	/* 424 */
+	uint8_t aes_key[NVBOOT_SE_AES_KEY256_LENGTH_BYTES];	/* 424 */
 
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];	/* 444 */
-	u_int32_t odm_data;					/* 508 */
-	u_int32_t reserved1;
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];	/* 444 */
+	uint32_t odm_data;					/* 508 */
+	uint32_t reserved1;
 
 	/* START OF SIGNED SECTION OF THE BCT */
 	nvboot_hash random_aes_blk;			/* 0x510 */
 	nvboot_ecid unique_chip_id;			/* 0x520 */
-	u_int32_t boot_data_version;			/* 0x530 */
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;			/* 0x530 */
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;			/* 0x588 */
+	uint32_t num_sdram_sets;			/* 0x588 */
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS]; /* 0x58c */
 
-	u_int32_t bootloader_used;				/* 0x232c */
+	uint32_t bootloader_used;				/* 0x232c */
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];	/* 0x2330 */
 
-	u_int8_t enable_fail_back;
+	uint8_t enable_fail_back;
 
 	/**
 	 * Specifies which debug features to be enabled or disabled.
@@ -377,7 +377,7 @@ typedef struct nvboot_config_table_rec {
 	 * DEVICEEN - bit 1
 	 * JTAG_ENABLE - bit 0
 	 */
-	u_int32_t secure_debug_control;
+	uint32_t secure_debug_control;
 
 	/**
 	 * Specifies the factory secure provisioning key number to use.
@@ -399,8 +399,8 @@ typedef struct nvboot_config_table_rec {
 	 *
 	 * This key number must match SecProvisioningKeyNum_Insecure.
 	 */
-	u_int32_t secure_provisioning_key_number_secure;
+	uint32_t secure_provisioning_key_number_secure;
 
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T210_H */

--- a/src/t210/nvboot_sdram_param_t210.h
+++ b/src/t210/nvboot_sdram_param_t210.h
@@ -66,470 +66,470 @@ typedef struct nvboot_sdram_params_rec {
 	/* MC/EMC clock source configuration */
 
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 	/* Specifies misc. control bits */
-	u_int32_t pllm_setup_control;
+	uint32_t pllm_setup_control;
 	/* Specifies the P value for PLLM */
-	u_int32_t pllm_post_divider;
+	uint32_t pllm_post_divider;
 	/* Specifies value for Charge Pump Gain Control */
-	u_int32_t pllm_kcp;
+	uint32_t pllm_kcp;
 	/* Specifies VCO gain */
-	u_int32_t pllm_kvco;
+	uint32_t pllm_kvco;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare0;
+	uint32_t emc_bct_spare0;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare1;
+	uint32_t emc_bct_spare1;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare2;
+	uint32_t emc_bct_spare2;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare3;
+	uint32_t emc_bct_spare3;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare4;
+	uint32_t emc_bct_spare4;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare5;
+	uint32_t emc_bct_spare5;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare6;
+	uint32_t emc_bct_spare6;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare7;
+	uint32_t emc_bct_spare7;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare8;
+	uint32_t emc_bct_spare8;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare9;
+	uint32_t emc_bct_spare9;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare10;
+	uint32_t emc_bct_spare10;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare11;
+	uint32_t emc_bct_spare11;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare12;
+	uint32_t emc_bct_spare12;
 	/* Spare BCT param */
-	u_int32_t emc_bct_spare13;
+	uint32_t emc_bct_spare13;
 
 	/* Defines EMC_2X_CLK_SRC, EMC_2X_CLK_DIVISOR, EMC_INVERT_DCD */
-	u_int32_t emc_clock_source;
-	u_int32_t emc_clock_source_dll;
+	uint32_t emc_clock_source;
+	uint32_t emc_clock_source_dll;
 
 	/* Defines possible override for PLLLM_MISC2 */
-	u_int32_t clk_rst_pllm_misc20_override;
+	uint32_t clk_rst_pllm_misc20_override;
 	/* enables override for PLLLM_MISC2 */
-	u_int32_t clk_rst_pllm_misc20_override_enable;
+	uint32_t clk_rst_pllm_misc20_override_enable;
 	/* defines CLK_ENB_MC1 in register clk_rst_controller_clk_enb_w_clr */
-	u_int32_t clear_clock2_mc1;
+	uint32_t clear_clock2_mc1;
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/*
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG2 */
-	u_int32_t emc_auto_cal_config2;
+	uint32_t emc_auto_cal_config2;
 
 	/* Specifies the value for EMC_AUTO_CAL_CONFIG3 */
-	u_int32_t emc_auto_cal_config3;
+	uint32_t emc_auto_cal_config3;
 
-	u_int32_t emc_auto_cal_config4;
-	u_int32_t emc_auto_cal_config5;
-	u_int32_t emc_auto_cal_config6;
-	u_int32_t emc_auto_cal_config7;
-	u_int32_t emc_auto_cal_config8;
+	uint32_t emc_auto_cal_config4;
+	uint32_t emc_auto_cal_config5;
+	uint32_t emc_auto_cal_config6;
+	uint32_t emc_auto_cal_config7;
+	uint32_t emc_auto_cal_config8;
 	/* Specifies the value for EMC_AUTO_CAL_VREF_SEL_0 */
-	u_int32_t emc_auto_cal_vref_sel0;
-	u_int32_t emc_auto_cal_vref_sel1;
+	uint32_t emc_auto_cal_vref_sel0;
+	uint32_t emc_auto_cal_vref_sel1;
 
 	/* Specifies the value for EMC_AUTO_CAL_CHANNEL */
-	u_int32_t emc_auto_cal_channel;
+	uint32_t emc_auto_cal_channel;
 
 	/* Specifies the value for EMC_PMACRO_AUTOCAL_CFG_0 */
-	u_int32_t emc_pmacro_auto_cal_cfg0;
-	u_int32_t emc_pmacro_auto_cal_cfg1;
-	u_int32_t emc_pmacro_auto_cal_cfg2;
+	uint32_t emc_pmacro_auto_cal_cfg0;
+	uint32_t emc_pmacro_auto_cal_cfg1;
+	uint32_t emc_pmacro_auto_cal_cfg2;
 
-	u_int32_t emc_pmacro_rx_term;
-	u_int32_t emc_pmacro_dq_tx_drive;
-	u_int32_t emc_pmacro_ca_tx_drive;
-	u_int32_t emc_pmacro_cmd_tx_drive;
-	u_int32_t emc_pmacro_auto_cal_common;
-	u_int32_t emc_pmacro_zcrtl;
+	uint32_t emc_pmacro_rx_term;
+	uint32_t emc_pmacro_dq_tx_drive;
+	uint32_t emc_pmacro_ca_tx_drive;
+	uint32_t emc_pmacro_cmd_tx_drive;
+	uint32_t emc_pmacro_auto_cal_common;
+	uint32_t emc_pmacro_zcrtl;
 
 	/*
 	 * Specifies the time for the calibration
 	 * to stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
-	u_int32_t emc_xm2_comp_pad_ctrl;
-	u_int32_t emc_xm2_comp_pad_ctrl2;
-	u_int32_t emc_xm2_comp_pad_ctrl3;
+	uint32_t emc_xm2_comp_pad_ctrl;
+	uint32_t emc_xm2_comp_pad_ctrl2;
+	uint32_t emc_xm2_comp_pad_ctrl3;
 
 	/*
 	 * DRAM size information
 	 * Specifies the value for EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 
 	/*
 	 * Specifies the time to wait after asserting pin
 	 * CKE (in microseconds)
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 	/* Specifies the extra delay before/after pin RESET/CKE command */
-	u_int32_t emc_pin_extra_wait;
+	uint32_t emc_pin_extra_wait;
 
-	u_int32_t emc_pin_gpio_enable;
-	u_int32_t emc_pin_gpio;
+	uint32_t emc_pin_gpio_enable;
+	uint32_t emc_pin_gpio;
 
 	/*
 	 * Specifies the extra delay after the first writing
 	 * of EMC_TIMING_CONTROL
 	 */
-	u_int32_t emc_timing_control_wait;
+	uint32_t emc_timing_control_wait;
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 
-	u_int32_t emc_rfc_pb;
-	u_int32_t emc_ref_ctrl2;
+	uint32_t emc_rfc_pb;
+	uint32_t emc_ref_ctrl2;
 
 	/* Specifies the value for EMC_RFC_SLR */
-	u_int32_t emc_rfc_slr;
+	uint32_t emc_rfc_slr;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2R */
-	u_int32_t emc_r2r;
+	uint32_t emc_r2r;
 	/* Specifies the value for EMC_W2W */
-	u_int32_t emc_w2w;
+	uint32_t emc_w2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_W2R */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
 
-	u_int32_t emc_tppd;
-	u_int32_t emc_ccdmw;
+	uint32_t emc_tppd;
+	uint32_t emc_ccdmw;
 
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WEXT */
-	u_int32_t emc_wext;
+	uint32_t emc_wext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 
-	u_int32_t emc_wdv_chk;
-	u_int32_t emc_wsv;
-	u_int32_t emc_wev;
+	uint32_t emc_wdv_chk;
+	uint32_t emc_wsv;
+	uint32_t emc_wev;
 
 	/* Specifies the value for EMC_WDV_MASK */
-	u_int32_t emc_wdv_mask;
+	uint32_t emc_wdv_mask;
 
-	u_int32_t emc_ws_duration;
-	u_int32_t emc_we_duration;
+	uint32_t emc_ws_duration;
+	uint32_t emc_we_duration;
 
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_QUSE_WIDTH */
-	u_int32_t emc_quse_width;
+	uint32_t emc_quse_width;
 	/* Specifies the value for EMC_IBDLY */
-	u_int32_t emc_ibdly;
+	uint32_t emc_ibdly;
 
-	u_int32_t emc_obdly;
+	uint32_t emc_obdly;
 
 	/* Specifies the value for EMC_EINPUT */
-	u_int32_t emc_einput;
+	uint32_t emc_einput;
 	/* Specifies the value for EMC_EINPUT_DURATION */
-	u_int32_t emc_einput_duration;
+	uint32_t emc_einput_duration;
 	/* Specifies the value for EMC_PUTERM_EXTRA */
-	u_int32_t emc_puterm_extra;
+	uint32_t emc_puterm_extra;
 	/* Specifies the value for EMC_PUTERM_WIDTH */
-	u_int32_t emc_puterm_width;
+	uint32_t emc_puterm_width;
 
-	u_int32_t emc_qrst;
-	u_int32_t emc_qsafe;
-	u_int32_t emc_rdv;
-	u_int32_t emc_rdv_mask;
+	uint32_t emc_qrst;
+	uint32_t emc_qsafe;
+	uint32_t emc_rdv;
+	uint32_t emc_rdv_mask;
 
-	u_int32_t emc_rdv_early;
-	u_int32_t emc_rdv_early_mask;
+	uint32_t emc_rdv_early;
+	uint32_t emc_rdv_early_mask;
 
 	/* Specifies the value for EMC_QPOP */
-	u_int32_t emc_qpop;
+	uint32_t emc_qpop;
 
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PRE_REFRESH_REQ_CNT */
-	u_int32_t emc_prerefresh_req_cnt;
+	uint32_t emc_prerefresh_req_cnt;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 
-	u_int32_t emc_cke2pden;
-	u_int32_t emc_pdex2che;
-	u_int32_t emc_pdex2mrr;
+	uint32_t emc_cke2pden;
+	uint32_t emc_pdex2che;
+	uint32_t emc_pdex2mrr;
 
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TXSRDLL */
-	u_int32_t emc_txsr_dll;
+	uint32_t emc_txsr_dll;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TCKESR */
-	u_int32_t emc_tckesr;
+	uint32_t emc_tckesr;
 	/* Specifies the value for EMC_TPD */
-	u_int32_t emc_tpd;
+	uint32_t emc_tpd;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG7 */
-	u_int32_t emc_fbio_cfg7;
-	u_int32_t emc_fbio_cfg8;
+	uint32_t emc_fbio_cfg7;
+	uint32_t emc_fbio_cfg8;
 
 	/* Command mapping for CMD brick 0 */
-	u_int32_t emc_cmd_mapping_cmd0_0;
-	u_int32_t emc_cmd_mapping_cmd0_1;
-	u_int32_t emc_cmd_mapping_cmd0_2;
-	u_int32_t emc_cmd_mapping_cmd1_0;
-	u_int32_t emc_cmd_mapping_cmd1_1;
-	u_int32_t emc_cmd_mapping_cmd1_2;
-	u_int32_t emc_cmd_mapping_cmd2_0;
-	u_int32_t emc_cmd_mapping_cmd2_1;
-	u_int32_t emc_cmd_mapping_cmd2_2;
-	u_int32_t emc_cmd_mapping_cmd3_0;
-	u_int32_t emc_cmd_mapping_cmd3_1;
-	u_int32_t emc_cmd_mapping_cmd3_2;
-	u_int32_t emc_cmd_mapping_byte;
+	uint32_t emc_cmd_mapping_cmd0_0;
+	uint32_t emc_cmd_mapping_cmd0_1;
+	uint32_t emc_cmd_mapping_cmd0_2;
+	uint32_t emc_cmd_mapping_cmd1_0;
+	uint32_t emc_cmd_mapping_cmd1_1;
+	uint32_t emc_cmd_mapping_cmd1_2;
+	uint32_t emc_cmd_mapping_cmd2_0;
+	uint32_t emc_cmd_mapping_cmd2_1;
+	uint32_t emc_cmd_mapping_cmd2_2;
+	uint32_t emc_cmd_mapping_cmd3_0;
+	uint32_t emc_cmd_mapping_cmd3_1;
+	uint32_t emc_cmd_mapping_cmd3_2;
+	uint32_t emc_cmd_mapping_byte;
 
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 	/* Specifies the value for EMC_CFG_RSV */
-	u_int32_t emc_cfg_rsv;
+	uint32_t emc_cfg_rsv;
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the MP0 command to initialize mode registers */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the MP2 command to initialize mode registers */
-	u_int32_t emc_emrs2;
+	uint32_t emc_emrs2;
 	/* Specifies the MP3 command to initialize mode registers */
-	u_int32_t emc_emrs3;
+	uint32_t emc_emrs3;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at cold boot */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at cold boot */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 	/* Specifies the programming to LPDDR2 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw4;
+	uint32_t emc_mrw4;
 
 	/* Specifies the programming to LPDDR4 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw6;
+	uint32_t emc_mrw6;
 	/* Specifies the programming to LPDDR4 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw8;
+	uint32_t emc_mrw8;
 	/* Specifies the programming to LPDDR4 Mode Register 11 at cold boot */
-	u_int32_t emc_mrw9;
+	uint32_t emc_mrw9;
 	/* Specifies the programming to LPDDR4 Mode Register 12 at cold boot */
-	u_int32_t emc_mrw10;
+	uint32_t emc_mrw10;
 	/* Specifies the programming to LPDDR4 Mode Register 14 at cold boot */
-	u_int32_t emc_mrw12;
+	uint32_t emc_mrw12;
 	/* Specifies the programming to LPDDR4 Mode Register 14 at cold boot */
-	u_int32_t emc_mrw13;
+	uint32_t emc_mrw13;
 	/* Specifies the programming to LPDDR4 Mode Register 22 at cold boot */
-	u_int32_t emc_mrw14;
+	uint32_t emc_mrw14;
 
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at cold boot
 	 */
-	u_int32_t emc_mrw_extra;
+	uint32_t emc_mrw_extra;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at warm boot
 	 */
-	u_int32_t emc_warm_boot_mrw_extra;
+	uint32_t emc_warm_boot_mrw_extra;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * warm boot
 	 */
-	u_int32_t emc_warm_boot_extramode_reg_write_enable;
+	uint32_t emc_warm_boot_extramode_reg_write_enable;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * cold boot
 	 */
-	u_int32_t emc_extramode_reg_write_enable;
+	uint32_t emc_extramode_reg_write_enable;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 	/* Specifies the value for EMC_MRS_WAIT_CNT */
-	u_int32_t emc_mrs_wait_cnt;
+	uint32_t emc_mrs_wait_cnt;
 	/* Specifies the value for EMC_MRS_WAIT_CNT2 */
-	u_int32_t emc_mrs_wait_cnt2;
+	uint32_t emc_mrs_wait_cnt2;
 
 	/* EMC miscellaneous configurations */
 
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the pipe bypass controls */
-	u_int32_t emc_cfg_pipe;
+	uint32_t emc_cfg_pipe;
 
-	u_int32_t emc_cfg_pipe_clk;
-	u_int32_t emc_fdpd_ctrl_cmd_no_ramp;
-	u_int32_t emc_cfg_update;
+	uint32_t emc_cfg_pipe_clk;
+	uint32_t emc_fdpd_ctrl_cmd_no_ramp;
+	uint32_t emc_cfg_update;
 
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 
-	u_int32_t emc_dbg_write_mux;
+	uint32_t emc_dbg_write_mux;
 
 	/* Specifies the value for EMC_CMDQ */
-	u_int32_t emc_cmd_q;
+	uint32_t emc_cmd_q;
 	/* Specifies the value for EMC_MC2EMCQ */
-	u_int32_t emc_mc2emc_q;
+	uint32_t emc_mc2emc_q;
 	/* Specifies the value for EMC_DYN_SELF_REF_CONTROL */
-	u_int32_t emc_dyn_self_ref_control;
+	uint32_t emc_dyn_self_ref_control;
 
 	/* Specifies the value for MEM_INIT_DONE */
-	u_int32_t ahb_arbitration_xbar_ctrl_meminit_done;
+	uint32_t ahb_arbitration_xbar_ctrl_meminit_done;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL */
-	u_int32_t emc_cfg_dig_dll;
-	u_int32_t emc_cfg_dig_dll_1;
+	uint32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll_1;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL_PERIOD */
-	u_int32_t emc_cfg_dig_dll_period;
+	uint32_t emc_cfg_dig_dll_period;
 	/* Specifies the value of *DEV_SELECTN of various EMC registers */
-	u_int32_t emc_dev_select;
+	uint32_t emc_dev_select;
 
 	/* Specifies the value for EMC_SEL_DPD_CTRL */
-	u_int32_t emc_sel_dpd_ctrl;
+	uint32_t emc_sel_dpd_ctrl;
 
 	/* Pads trimmer delays */
-	u_int32_t emc_fdpd_ctrl_dq;
-	u_int32_t emc_fdpd_ctrl_cmd;
-	u_int32_t emc_pmacro_ib_vref_dq_0;
-	u_int32_t emc_pmacro_ib_vref_dq_1;
-	u_int32_t emc_pmacro_ib_vref_dqs_0;
-	u_int32_t emc_pmacro_ib_vref_dqs_1;
-	u_int32_t emc_pmacro_ib_rxrt;
-	u_int32_t emc_cfg_pipe1;
-	u_int32_t emc_cfg_pipe2;
+	uint32_t emc_fdpd_ctrl_dq;
+	uint32_t emc_fdpd_ctrl_cmd;
+	uint32_t emc_pmacro_ib_vref_dq_0;
+	uint32_t emc_pmacro_ib_vref_dq_1;
+	uint32_t emc_pmacro_ib_vref_dqs_0;
+	uint32_t emc_pmacro_ib_vref_dqs_1;
+	uint32_t emc_pmacro_ib_rxrt;
+	uint32_t emc_cfg_pipe1;
+	uint32_t emc_cfg_pipe2;
 
 	/* Specifies the value for EMC_PMACRO_QUSE_DDLL_RANK0_0 */
-	u_int32_t emc_pmacro_quse_ddll_rank0_0;
-	u_int32_t emc_pmacro_quse_ddll_rank0_1;
-	u_int32_t emc_pmacro_quse_ddll_rank0_2;
-	u_int32_t emc_pmacro_quse_ddll_rank0_3;
-	u_int32_t emc_pmacro_quse_ddll_rank0_4;
-	u_int32_t emc_pmacro_quse_ddll_rank0_5;
-	u_int32_t emc_pmacro_quse_ddll_rank1_0;
-	u_int32_t emc_pmacro_quse_ddll_rank1_1;
-	u_int32_t emc_pmacro_quse_ddll_rank1_2;
-	u_int32_t emc_pmacro_quse_ddll_rank1_3;
-	u_int32_t emc_pmacro_quse_ddll_rank1_4;
-	u_int32_t emc_pmacro_quse_ddll_rank1_5;
+	uint32_t emc_pmacro_quse_ddll_rank0_0;
+	uint32_t emc_pmacro_quse_ddll_rank0_1;
+	uint32_t emc_pmacro_quse_ddll_rank0_2;
+	uint32_t emc_pmacro_quse_ddll_rank0_3;
+	uint32_t emc_pmacro_quse_ddll_rank0_4;
+	uint32_t emc_pmacro_quse_ddll_rank0_5;
+	uint32_t emc_pmacro_quse_ddll_rank1_0;
+	uint32_t emc_pmacro_quse_ddll_rank1_1;
+	uint32_t emc_pmacro_quse_ddll_rank1_2;
+	uint32_t emc_pmacro_quse_ddll_rank1_3;
+	uint32_t emc_pmacro_quse_ddll_rank1_4;
+	uint32_t emc_pmacro_quse_ddll_rank1_5;
 
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_0;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_1;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_2;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_3;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_4;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank0_5;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_0;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_1;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_2;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_3;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_4;
-	u_int32_t emc_pmacro_ob_ddll_long_dq_rank1_5;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_0;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_1;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_2;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_3;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_4;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank0_5;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_0;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_1;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_2;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_3;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_4;
+	uint32_t emc_pmacro_ob_ddll_long_dq_rank1_5;
 
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_0;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_1;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_2;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_3;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_4;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank0_5;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_0;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_1;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_2;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_3;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_4;
-	u_int32_t emc_pmacro_ob_ddll_long_dqs_rank1_5;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_0;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_1;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_2;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_3;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_4;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank0_5;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_0;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_1;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_2;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_3;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_4;
+	uint32_t emc_pmacro_ob_ddll_long_dqs_rank1_5;
 
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank0_0;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank0_1;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank0_2;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank0_3;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank1_0;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank1_1;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank1_2;
-	u_int32_t emc_pmacro_ib_ddll_long_dqs_rank1_3;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank0_0;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank0_1;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank0_2;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank0_3;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank1_0;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank1_1;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank1_2;
+	uint32_t emc_pmacro_ib_ddll_long_dqs_rank1_3;
 
-	u_int32_t emc_pmacro_ddll_long_cmd_0;
-	u_int32_t emc_pmacro_ddll_long_cmd_1;
-	u_int32_t emc_pmacro_ddll_long_cmd_2;
-	u_int32_t emc_pmacro_ddll_long_cmd_3;
-	u_int32_t emc_pmacro_ddll_long_cmd_4;
-	u_int32_t emc_pmacro_ddll_short_cmd_0;
-	u_int32_t emc_pmacro_ddll_short_cmd_1;
-	u_int32_t emc_pmacro_ddll_short_cmd_2;
+	uint32_t emc_pmacro_ddll_long_cmd_0;
+	uint32_t emc_pmacro_ddll_long_cmd_1;
+	uint32_t emc_pmacro_ddll_long_cmd_2;
+	uint32_t emc_pmacro_ddll_long_cmd_3;
+	uint32_t emc_pmacro_ddll_long_cmd_4;
+	uint32_t emc_pmacro_ddll_short_cmd_0;
+	uint32_t emc_pmacro_ddll_short_cmd_1;
+	uint32_t emc_pmacro_ddll_short_cmd_2;
 
 	/*
 	 * Specifies the delay after asserting CKE pin during a WarmBoot0
 	 * sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 
 	/* Periodic ZQ calibration */
 
@@ -537,416 +537,416 @@ typedef struct nvboot_sdram_params_rec {
 	 * Specifies the value for EMC_ZCAL_INTERVAL
 	 * Value 0 disables ZQ calibration
 	 */
-	u_int32_t emc_zcal_interval;
+	uint32_t emc_zcal_interval;
 	/* Specifies the value for EMC_ZCAL_WAIT_CNT */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/* Specifies the value for EMC_ZCAL_MRW_CMD */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/* DRAM initialization sequence flow control */
 
 	/* Specifies the MRS command value for resetting DLL */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the command for ZQ initialization of device 0 */
-	u_int32_t emc_zcal_init_dev0;
+	uint32_t emc_zcal_init_dev0;
 	/* Specifies the command for ZQ initialization of device 1 */
-	u_int32_t emc_zcal_init_dev1;
+	uint32_t emc_zcal_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_zcal_init_wait;
+	uint32_t emc_zcal_init_wait;
 	/*
 	 * Specifies the enable for ZQ calibration at cold boot [bit 0]
 	 * and warm boot [bit 1]
 	 */
-	u_int32_t emc_zcal_warm_cold_boot_enables;
+	uint32_t emc_zcal_warm_cold_boot_enables;
 
 	/*
 	 * Specifies the MRW command to LPDDR2 for ZQ calibration
 	 * on warmboot
 	 */
 	/* Is issued to both devices separately */
-	u_int32_t emc_mrw_lpddr2zcal_warm_boot;
+	uint32_t emc_mrw_lpddr2zcal_warm_boot;
 	/*
 	 * Specifies the ZQ command to DDR3 for ZQ calibration on warmboot
 	 * Is issued to both devices separately
 	 */
-	u_int32_t emc_zqcal_ddr3_warm_boot;
+	uint32_t emc_zqcal_ddr3_warm_boot;
 
-	u_int32_t emc_zqcal_lpddr4_warm_boot;
+	uint32_t emc_zqcal_lpddr4_warm_boot;
 
 	/*
 	 * Specifies the wait time for ZQ calibration on warmboot
 	 * (in microseconds)
 	 */
-	u_int32_t emc_zcal_warm_boot_wait;
+	uint32_t emc_zcal_warm_boot_wait;
 	/*
 	 * Specifies the enable for DRAM Mode Register programming
 	 * at warm boot
 	 */
-	u_int32_t emc_mrs_warm_boot_enable;
+	uint32_t emc_mrs_warm_boot_enable;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/* Specifies the extra MRS command to initialize mode registers */
-	u_int32_t emc_mrs_extra;
+	uint32_t emc_mrs_extra;
 	/* Specifies the extra MRS command at warm boot */
-	u_int32_t emc_warm_boot_mrs_extra;
+	uint32_t emc_warm_boot_mrs_extra;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 	/* Specifies the value for EMC_CLKEN_OVERRIDE */
-	u_int32_t emc_clken_override;
+	uint32_t emc_clken_override;
 	/*
 	 * Specifies LOG2 of the extra refresh numbers after booting
 	 * Program 0 to disable
 	 */
-	u_int32_t emc_extra_refresh_num;
+	uint32_t emc_extra_refresh_num;
 	/* Specifies the master override for all EMC clocks */
-	u_int32_t emc_clken_override_allwarm_boot;
+	uint32_t emc_clken_override_allwarm_boot;
 	/* Specifies the master override for all MC clocks */
-	u_int32_t mc_clken_override_allwarm_boot;
+	uint32_t mc_clken_override_allwarm_boot;
 	/* Specifies digital dll period, choosing between 4 to 64 ms */
-	u_int32_t emc_cfg_dig_dll_period_warm_boot;
+	uint32_t emc_cfg_dig_dll_period_warm_boot;
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel;
+	uint32_t pmc_vddp_sel;
 	/* Specifies the wait time after programming PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel_wait;
+	uint32_t pmc_vddp_sel_wait;
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for PMC_DDR_CFG */
-	u_int32_t pmc_ddr_cfg;
+	uint32_t pmc_ddr_cfg;
 	/* Specifies the value for PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req;
+	uint32_t pmc_io_dpd3_req;
 	/* Specifies the wait time after programming PMC_IO_DPD3_REQ */
-	u_int32_t pmc_io_dpd3_req_wait;
+	uint32_t pmc_io_dpd3_req_wait;
 
-	u_int32_t pmc_io_dpd4_req_wait;
+	uint32_t pmc_io_dpd4_req_wait;
 
 	/* Specifies the value for PMC_REG_SHORT */
-	u_int32_t pmc_reg_short;
+	uint32_t pmc_reg_short;
 	/* Specifies the value for PMC_NO_IOPOWER */
-	u_int32_t pmc_no_io_power;
+	uint32_t pmc_no_io_power;
 
-	u_int32_t pmc_ddr_ctrl_wait;
-	u_int32_t pmc_ddr_ctrl;
+	uint32_t pmc_ddr_ctrl_wait;
+	uint32_t pmc_ddr_ctrl;
 
 	/* Specifies the value for EMC_ACPD_CONTROL */
-	u_int32_t emc_acpd_control;
+	uint32_t emc_acpd_control;
 
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
-	u_int32_t emc_swizzle_rank0_byte0;
+	uint32_t emc_swizzle_rank0_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
-	u_int32_t emc_swizzle_rank0_byte1;
+	uint32_t emc_swizzle_rank0_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE2 */
-	u_int32_t emc_swizzle_rank0_byte2;
+	uint32_t emc_swizzle_rank0_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
-	u_int32_t emc_swizzle_rank0_byte3;
+	uint32_t emc_swizzle_rank0_byte3;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
-	u_int32_t emc_swizzle_rank1_byte0;
+	uint32_t emc_swizzle_rank1_byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */
-	u_int32_t emc_swizzle_rank1_byte1;
+	uint32_t emc_swizzle_rank1_byte1;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE2 */
-	u_int32_t emc_swizzle_rank1_byte2;
+	uint32_t emc_swizzle_rank1_byte2;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE3 */
-	u_int32_t emc_swizzle_rank1_byte3;
+	uint32_t emc_swizzle_rank1_byte3;
 
 	/* Specifies the value for EMC_TXDSRVTTGEN */
-	u_int32_t emc_txdsrvttgen;
+	uint32_t emc_txdsrvttgen;
 
 	/* Specifies the value for EMC_DATA_BRLSHFT_0 */
-	u_int32_t emc_data_brlshft0;
-	u_int32_t emc_data_brlshft1;
+	uint32_t emc_data_brlshft0;
+	uint32_t emc_data_brlshft1;
 
-	u_int32_t emc_dqs_brlshft0;
-	u_int32_t emc_dqs_brlshft1;
+	uint32_t emc_dqs_brlshft0;
+	uint32_t emc_dqs_brlshft1;
 
-	u_int32_t emc_cmd_brlshft0;
-	u_int32_t emc_cmd_brlshft1;
-	u_int32_t emc_cmd_brlshft2;
-	u_int32_t emc_cmd_brlshft3;
+	uint32_t emc_cmd_brlshft0;
+	uint32_t emc_cmd_brlshft1;
+	uint32_t emc_cmd_brlshft2;
+	uint32_t emc_cmd_brlshft3;
 
-	u_int32_t emc_quse_brlshft0;
-	u_int32_t emc_quse_brlshft1;
-	u_int32_t emc_quse_brlshft2;
-	u_int32_t emc_quse_brlshft3;
+	uint32_t emc_quse_brlshft0;
+	uint32_t emc_quse_brlshft1;
+	uint32_t emc_quse_brlshft2;
+	uint32_t emc_quse_brlshft3;
 
-	u_int32_t emc_dll_cfg0;
-	u_int32_t emc_dll_cfg1;
+	uint32_t emc_dll_cfg0;
+	uint32_t emc_dll_cfg1;
 
-	u_int32_t emc_pmc_scratch1;
-	u_int32_t emc_pmc_scratch2;
-	u_int32_t emc_pmc_scratch3;
+	uint32_t emc_pmc_scratch1;
+	uint32_t emc_pmc_scratch2;
+	uint32_t emc_pmc_scratch3;
 
-	u_int32_t emc_pmacro_pad_cfg_ctrl;
+	uint32_t emc_pmacro_pad_cfg_ctrl;
 
-	u_int32_t emc_pmacro_vttgen_ctrl0;
-	u_int32_t emc_pmacro_vttgen_ctrl1;
-	u_int32_t emc_pmacro_vttgen_ctrl2;
+	uint32_t emc_pmacro_vttgen_ctrl0;
+	uint32_t emc_pmacro_vttgen_ctrl1;
+	uint32_t emc_pmacro_vttgen_ctrl2;
 
-	u_int32_t emc_pmacro_brick_ctrl_rfu1;
-	u_int32_t emc_pmacro_cmd_brick_ctrl_fdpd;
-	u_int32_t emc_pmacro_brick_ctrl_rfu2;
-	u_int32_t emc_pmacro_data_brick_ctrl_fdpd;
-	u_int32_t emc_pmacro_bg_bias_ctrl0;
-	u_int32_t emc_pmacro_data_pad_rx_ctrl;
-	u_int32_t emc_pmacro_cmd_pad_rx_ctrl;
-	u_int32_t emc_pmacro_data_rx_term_mode;
-	u_int32_t emc_pmacro_cmd_rx_term_mode;
-	u_int32_t emc_pmacro_data_pad_tx_ctrl;
-	u_int32_t emc_pmacro_common_pad_tx_ctrl;
-	u_int32_t emc_pmacro_cmd_pad_tx_ctrl;
-	u_int32_t emc_cfg3;
+	uint32_t emc_pmacro_brick_ctrl_rfu1;
+	uint32_t emc_pmacro_cmd_brick_ctrl_fdpd;
+	uint32_t emc_pmacro_brick_ctrl_rfu2;
+	uint32_t emc_pmacro_data_brick_ctrl_fdpd;
+	uint32_t emc_pmacro_bg_bias_ctrl0;
+	uint32_t emc_pmacro_data_pad_rx_ctrl;
+	uint32_t emc_pmacro_cmd_pad_rx_ctrl;
+	uint32_t emc_pmacro_data_rx_term_mode;
+	uint32_t emc_pmacro_cmd_rx_term_mode;
+	uint32_t emc_pmacro_data_pad_tx_ctrl;
+	uint32_t emc_pmacro_common_pad_tx_ctrl;
+	uint32_t emc_pmacro_cmd_pad_tx_ctrl;
+	uint32_t emc_cfg3;
 
-	u_int32_t emc_pmacro_tx_pwrd0;
-	u_int32_t emc_pmacro_tx_pwrd1;
-	u_int32_t emc_pmacro_tx_pwrd2;
-	u_int32_t emc_pmacro_tx_pwrd3;
-	u_int32_t emc_pmacro_tx_pwrd4;
-	u_int32_t emc_pmacro_tx_pwrd5;
+	uint32_t emc_pmacro_tx_pwrd0;
+	uint32_t emc_pmacro_tx_pwrd1;
+	uint32_t emc_pmacro_tx_pwrd2;
+	uint32_t emc_pmacro_tx_pwrd3;
+	uint32_t emc_pmacro_tx_pwrd4;
+	uint32_t emc_pmacro_tx_pwrd5;
 
-	u_int32_t emc_config_sample_delay;
+	uint32_t emc_config_sample_delay;
 
-	u_int32_t emc_pmacro_brick_mapping0;
-	u_int32_t emc_pmacro_brick_mapping1;
-	u_int32_t emc_pmacro_brick_mapping2;
+	uint32_t emc_pmacro_brick_mapping0;
+	uint32_t emc_pmacro_brick_mapping1;
+	uint32_t emc_pmacro_brick_mapping2;
 
-	u_int32_t emc_pmacro_tx_sel_clk_src0;
-	u_int32_t emc_pmacro_tx_sel_clk_src1;
-	u_int32_t emc_pmacro_tx_sel_clk_src2;
-	u_int32_t emc_pmacro_tx_sel_clk_src3;
-	u_int32_t emc_pmacro_tx_sel_clk_src4;
-	u_int32_t emc_pmacro_tx_sel_clk_src5;
+	uint32_t emc_pmacro_tx_sel_clk_src0;
+	uint32_t emc_pmacro_tx_sel_clk_src1;
+	uint32_t emc_pmacro_tx_sel_clk_src2;
+	uint32_t emc_pmacro_tx_sel_clk_src3;
+	uint32_t emc_pmacro_tx_sel_clk_src4;
+	uint32_t emc_pmacro_tx_sel_clk_src5;
 
-	u_int32_t emc_pmacro_ddll_bypass;
+	uint32_t emc_pmacro_ddll_bypass;
 
-	u_int32_t emc_pmacro_ddll_pwrd0;
-	u_int32_t emc_pmacro_ddll_pwrd1;
-	u_int32_t emc_pmacro_ddll_pwrd2;
+	uint32_t emc_pmacro_ddll_pwrd0;
+	uint32_t emc_pmacro_ddll_pwrd1;
+	uint32_t emc_pmacro_ddll_pwrd2;
 
-	u_int32_t emc_pmacro_cmd_ctrl0;
-	u_int32_t emc_pmacro_cmd_ctrl1;
-	u_int32_t emc_pmacro_cmd_ctrl2;
+	uint32_t emc_pmacro_cmd_ctrl0;
+	uint32_t emc_pmacro_cmd_ctrl1;
+	uint32_t emc_pmacro_cmd_ctrl2;
 
 	/* DRAM size information */
 
 	/* Specifies the value for MC_EMEM_ADR_CFG */
-	u_int32_t mc_emem_adr_cfg;
+	uint32_t mc_emem_adr_cfg;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV0 */
-	u_int32_t mc_emem_adr_cfg_dev0;
+	uint32_t mc_emem_adr_cfg_dev0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV1 */
-	u_int32_t mc_emem_adr_cfg_dev1;
+	uint32_t mc_emem_adr_cfg_dev1;
 
-	u_int32_t mc_emem_adr_cfg_channel_mask;
+	uint32_t mc_emem_adr_cfg_channel_mask;
 
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG0 */
-	u_int32_t mc_emem_adr_cfg_bank_mask0;
+	uint32_t mc_emem_adr_cfg_bank_mask0;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG1 */
-	u_int32_t mc_emem_adr_cfg_bank_mask1;
+	uint32_t mc_emem_adr_cfg_bank_mask1;
 	/* Specifies the value for MC_EMEM_BANK_SWIZZLE_CFG2 */
-	u_int32_t mc_emem_adr_cfg_bank_mask2;
+	uint32_t mc_emem_adr_cfg_bank_mask2;
 
 	/*
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/* MC arbitration configuration */
 
 	/* Specifies the value for MC_EMEM_ARB_CFG */
-	u_int32_t mc_emem_arb_cfg;
+	uint32_t mc_emem_arb_cfg;
 	/* Specifies the value for MC_EMEM_ARB_OUTSTANDING_REQ */
-	u_int32_t mc_emem_arb_outstanding_req;
+	uint32_t mc_emem_arb_outstanding_req;
 
-	u_int32_t emc_emem_arb_refpb_hp_ctrl;
-	u_int32_t emc_emem_arb_refpb_bank_ctrl;
+	uint32_t emc_emem_arb_refpb_hp_ctrl;
+	uint32_t emc_emem_arb_refpb_bank_ctrl;
 
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RCD */
-	u_int32_t mc_emem_arb_timing_rcd;
+	uint32_t mc_emem_arb_timing_rcd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RP */
-	u_int32_t mc_emem_arb_timing_rp;
+	uint32_t mc_emem_arb_timing_rp;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RC */
-	u_int32_t mc_emem_arb_timing_rc;
+	uint32_t mc_emem_arb_timing_rc;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAS */
-	u_int32_t mc_emem_arb_timing_ras;
+	uint32_t mc_emem_arb_timing_ras;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_FAW */
-	u_int32_t mc_emem_arb_timing_faw;
+	uint32_t mc_emem_arb_timing_faw;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RRD */
-	u_int32_t mc_emem_arb_timing_rrd;
+	uint32_t mc_emem_arb_timing_rrd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAP2PRE */
-	u_int32_t mc_emem_arb_timing_rap2pre;
+	uint32_t mc_emem_arb_timing_rap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_WAP2PRE */
-	u_int32_t mc_emem_arb_timing_wap2pre;
+	uint32_t mc_emem_arb_timing_wap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2R */
-	u_int32_t mc_emem_arb_timing_r2r;
+	uint32_t mc_emem_arb_timing_r2r;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2W */
-	u_int32_t mc_emem_arb_timing_w2w;
+	uint32_t mc_emem_arb_timing_w2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2W */
-	u_int32_t mc_emem_arb_timing_r2w;
+	uint32_t mc_emem_arb_timing_r2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2R */
-	u_int32_t mc_emem_arb_timing_w2r;
+	uint32_t mc_emem_arb_timing_w2r;
 
-	u_int32_t mc_emem_arb_timing_rfcpb;
+	uint32_t mc_emem_arb_timing_rfcpb;
 
 	/* Specifies the value for MC_EMEM_ARB_DA_TURNS */
-	u_int32_t mc_emem_arb_da_turns;
+	uint32_t mc_emem_arb_da_turns;
 	/* Specifies the value for MC_EMEM_ARB_DA_COVERS */
-	u_int32_t mc_emem_arb_da_covers;
+	uint32_t mc_emem_arb_da_covers;
 	/* Specifies the value for MC_EMEM_ARB_MISC0 */
-	u_int32_t mc_emem_arb_misc0;
+	uint32_t mc_emem_arb_misc0;
 	/* Specifies the value for MC_EMEM_ARB_MISC1 */
-	u_int32_t mc_emem_arb_misc1;
-	u_int32_t mc_emem_arb_misc2;
+	uint32_t mc_emem_arb_misc1;
+	uint32_t mc_emem_arb_misc2;
 
 	/* Specifies the value for MC_EMEM_ARB_RING1_THROTTLE */
-	u_int32_t mc_emem_arb_ring1_throttle;
+	uint32_t mc_emem_arb_ring1_throttle;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE */
-	u_int32_t mc_emem_arb_override;
+	uint32_t mc_emem_arb_override;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE_1 */
-	u_int32_t mc_emem_arb_override1;
+	uint32_t mc_emem_arb_override1;
 	/* Specifies the value for MC_EMEM_ARB_RSV */
-	u_int32_t mc_emem_arb_rsv;
+	uint32_t mc_emem_arb_rsv;
 
-	u_int32_t mc_da_cfg0;
-	u_int32_t mc_emem_arb_timing_ccdmw;
+	uint32_t mc_da_cfg0;
+	uint32_t mc_emem_arb_timing_ccdmw;
 
 	/* Specifies the value for MC_CLKEN_OVERRIDE */
-	u_int32_t mc_clken_override;
+	uint32_t mc_clken_override;
 
 	/* Specifies the value for MC_STAT_CONTROL */
-	u_int32_t mc_stat_control;
+	uint32_t mc_stat_control;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM */
-	u_int32_t mc_video_protect_bom;
+	uint32_t mc_video_protect_bom;
 	/* Specifies the value for MC_VIDEO_PROTECT_BOM_ADR_HI */
-	u_int32_t mc_video_protect_bom_adr_hi;
+	uint32_t mc_video_protect_bom_adr_hi;
 	/* Specifies the value for MC_VIDEO_PROTECT_SIZE_MB */
-	u_int32_t mc_video_protect_size_mb;
+	uint32_t mc_video_protect_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE */
-	u_int32_t mc_video_protect_vpr_override;
+	uint32_t mc_video_protect_vpr_override;
 	/* Specifies the value for MC_VIDEO_PROTECT_VPR_OVERRIDE1 */
-	u_int32_t mc_video_protect_vpr_override1;
+	uint32_t mc_video_protect_vpr_override1;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_0 */
-	u_int32_t mc_video_protect_gpu_override0;
+	uint32_t mc_video_protect_gpu_override0;
 	/* Specifies the value for MC_VIDEO_PROTECT_GPU_OVERRIDE_1 */
-	u_int32_t mc_video_protect_gpu_override1;
+	uint32_t mc_video_protect_gpu_override1;
 	/* Specifies the value for MC_SEC_CARVEOUT_BOM */
-	u_int32_t mc_sec_carveout_bom;
+	uint32_t mc_sec_carveout_bom;
 	/* Specifies the value for MC_SEC_CARVEOUT_ADR_HI */
-	u_int32_t mc_sec_carveout_adr_hi;
+	uint32_t mc_sec_carveout_adr_hi;
 	/* Specifies the value for MC_SEC_CARVEOUT_SIZE_MB */
-	u_int32_t mc_sec_carveout_size_mb;
+	uint32_t mc_sec_carveout_size_mb;
 	/* Specifies the value for MC_VIDEO_PROTECT_REG_CTRL.VIDEO_PROTECT_WRITE_ACCESS */
-	u_int32_t mc_video_protect_write_access;
+	uint32_t mc_video_protect_write_access;
 	/* Specifies the value for MC_SEC_CARVEOUT_REG_CTRL.SEC_CARVEOUT_WRITE_ACCESS */
-	u_int32_t mc_sec_carveout_protect_write_access;
+	uint32_t mc_sec_carveout_protect_write_access;
 
-	u_int32_t mc_generalized_carveout1_bom;
-	u_int32_t mc_generalized_carveout1_bom_hi;
-	u_int32_t mc_generalized_carveout1_size_128kb;
-	u_int32_t mc_generalized_carveout1_access0;
-	u_int32_t mc_generalized_carveout1_access1;
-	u_int32_t mc_generalized_carveout1_access2;
-	u_int32_t mc_generalized_carveout1_access3;
-	u_int32_t mc_generalized_carveout1_access4;
-	u_int32_t mc_generalized_carveout1_force_internal_access0;
-	u_int32_t mc_generalized_carveout1_force_internal_access1;
-	u_int32_t mc_generalized_carveout1_force_internal_access2;
-	u_int32_t mc_generalized_carveout1_force_internal_access3;
-	u_int32_t mc_generalized_carveout1_force_internal_access4;
-	u_int32_t mc_generalized_carveout1_cfg0;
+	uint32_t mc_generalized_carveout1_bom;
+	uint32_t mc_generalized_carveout1_bom_hi;
+	uint32_t mc_generalized_carveout1_size_128kb;
+	uint32_t mc_generalized_carveout1_access0;
+	uint32_t mc_generalized_carveout1_access1;
+	uint32_t mc_generalized_carveout1_access2;
+	uint32_t mc_generalized_carveout1_access3;
+	uint32_t mc_generalized_carveout1_access4;
+	uint32_t mc_generalized_carveout1_force_internal_access0;
+	uint32_t mc_generalized_carveout1_force_internal_access1;
+	uint32_t mc_generalized_carveout1_force_internal_access2;
+	uint32_t mc_generalized_carveout1_force_internal_access3;
+	uint32_t mc_generalized_carveout1_force_internal_access4;
+	uint32_t mc_generalized_carveout1_cfg0;
 
-	u_int32_t mc_generalized_carveout2_bom;
-	u_int32_t mc_generalized_carveout2_bom_hi;
-	u_int32_t mc_generalized_carveout2_size_128kb;
-	u_int32_t mc_generalized_carveout2_access0;
-	u_int32_t mc_generalized_carveout2_access1;
-	u_int32_t mc_generalized_carveout2_access2;
-	u_int32_t mc_generalized_carveout2_access3;
-	u_int32_t mc_generalized_carveout2_access4;
-	u_int32_t mc_generalized_carveout2_force_internal_access0;
-	u_int32_t mc_generalized_carveout2_force_internal_access1;
-	u_int32_t mc_generalized_carveout2_force_internal_access2;
-	u_int32_t mc_generalized_carveout2_force_internal_access3;
-	u_int32_t mc_generalized_carveout2_force_internal_access4;
-	u_int32_t mc_generalized_carveout2_cfg0;
+	uint32_t mc_generalized_carveout2_bom;
+	uint32_t mc_generalized_carveout2_bom_hi;
+	uint32_t mc_generalized_carveout2_size_128kb;
+	uint32_t mc_generalized_carveout2_access0;
+	uint32_t mc_generalized_carveout2_access1;
+	uint32_t mc_generalized_carveout2_access2;
+	uint32_t mc_generalized_carveout2_access3;
+	uint32_t mc_generalized_carveout2_access4;
+	uint32_t mc_generalized_carveout2_force_internal_access0;
+	uint32_t mc_generalized_carveout2_force_internal_access1;
+	uint32_t mc_generalized_carveout2_force_internal_access2;
+	uint32_t mc_generalized_carveout2_force_internal_access3;
+	uint32_t mc_generalized_carveout2_force_internal_access4;
+	uint32_t mc_generalized_carveout2_cfg0;
 
-	u_int32_t mc_generalized_carveout3_bom;
-	u_int32_t mc_generalized_carveout3_bom_hi;
-	u_int32_t mc_generalized_carveout3_size_128kb;
-	u_int32_t mc_generalized_carveout3_access0;
-	u_int32_t mc_generalized_carveout3_access1;
-	u_int32_t mc_generalized_carveout3_access2;
-	u_int32_t mc_generalized_carveout3_access3;
-	u_int32_t mc_generalized_carveout3_access4;
-	u_int32_t mc_generalized_carveout3_force_internal_access0;
-	u_int32_t mc_generalized_carveout3_force_internal_access1;
-	u_int32_t mc_generalized_carveout3_force_internal_access2;
-	u_int32_t mc_generalized_carveout3_force_internal_access3;
-	u_int32_t mc_generalized_carveout3_force_internal_access4;
-	u_int32_t mc_generalized_carveout3_cfg0;
+	uint32_t mc_generalized_carveout3_bom;
+	uint32_t mc_generalized_carveout3_bom_hi;
+	uint32_t mc_generalized_carveout3_size_128kb;
+	uint32_t mc_generalized_carveout3_access0;
+	uint32_t mc_generalized_carveout3_access1;
+	uint32_t mc_generalized_carveout3_access2;
+	uint32_t mc_generalized_carveout3_access3;
+	uint32_t mc_generalized_carveout3_access4;
+	uint32_t mc_generalized_carveout3_force_internal_access0;
+	uint32_t mc_generalized_carveout3_force_internal_access1;
+	uint32_t mc_generalized_carveout3_force_internal_access2;
+	uint32_t mc_generalized_carveout3_force_internal_access3;
+	uint32_t mc_generalized_carveout3_force_internal_access4;
+	uint32_t mc_generalized_carveout3_cfg0;
 
-	u_int32_t mc_generalized_carveout4_bom;
-	u_int32_t mc_generalized_carveout4_bom_hi;
-	u_int32_t mc_generalized_carveout4_size_128kb;
-	u_int32_t mc_generalized_carveout4_access0;
-	u_int32_t mc_generalized_carveout4_access1;
-	u_int32_t mc_generalized_carveout4_access2;
-	u_int32_t mc_generalized_carveout4_access3;
-	u_int32_t mc_generalized_carveout4_access4;
-	u_int32_t mc_generalized_carveout4_force_internal_access0;
-	u_int32_t mc_generalized_carveout4_force_internal_access1;
-	u_int32_t mc_generalized_carveout4_force_internal_access2;
-	u_int32_t mc_generalized_carveout4_force_internal_access3;
-	u_int32_t mc_generalized_carveout4_force_internal_access4;
-	u_int32_t mc_generalized_carveout4_cfg0;
+	uint32_t mc_generalized_carveout4_bom;
+	uint32_t mc_generalized_carveout4_bom_hi;
+	uint32_t mc_generalized_carveout4_size_128kb;
+	uint32_t mc_generalized_carveout4_access0;
+	uint32_t mc_generalized_carveout4_access1;
+	uint32_t mc_generalized_carveout4_access2;
+	uint32_t mc_generalized_carveout4_access3;
+	uint32_t mc_generalized_carveout4_access4;
+	uint32_t mc_generalized_carveout4_force_internal_access0;
+	uint32_t mc_generalized_carveout4_force_internal_access1;
+	uint32_t mc_generalized_carveout4_force_internal_access2;
+	uint32_t mc_generalized_carveout4_force_internal_access3;
+	uint32_t mc_generalized_carveout4_force_internal_access4;
+	uint32_t mc_generalized_carveout4_cfg0;
 
-	u_int32_t mc_generalized_carveout5_bom;
-	u_int32_t mc_generalized_carveout5_bom_hi;
-	u_int32_t mc_generalized_carveout5_size_128kb;
-	u_int32_t mc_generalized_carveout5_access0;
-	u_int32_t mc_generalized_carveout5_access1;
-	u_int32_t mc_generalized_carveout5_access2;
-	u_int32_t mc_generalized_carveout5_access3;
-	u_int32_t mc_generalized_carveout5_access4;
-	u_int32_t mc_generalized_carveout5_force_internal_access0;
-	u_int32_t mc_generalized_carveout5_force_internal_access1;
-	u_int32_t mc_generalized_carveout5_force_internal_access2;
-	u_int32_t mc_generalized_carveout5_force_internal_access3;
-	u_int32_t mc_generalized_carveout5_force_internal_access4;
-	u_int32_t mc_generalized_carveout5_cfg0;
+	uint32_t mc_generalized_carveout5_bom;
+	uint32_t mc_generalized_carveout5_bom_hi;
+	uint32_t mc_generalized_carveout5_size_128kb;
+	uint32_t mc_generalized_carveout5_access0;
+	uint32_t mc_generalized_carveout5_access1;
+	uint32_t mc_generalized_carveout5_access2;
+	uint32_t mc_generalized_carveout5_access3;
+	uint32_t mc_generalized_carveout5_access4;
+	uint32_t mc_generalized_carveout5_force_internal_access0;
+	uint32_t mc_generalized_carveout5_force_internal_access1;
+	uint32_t mc_generalized_carveout5_force_internal_access2;
+	uint32_t mc_generalized_carveout5_force_internal_access3;
+	uint32_t mc_generalized_carveout5_force_internal_access4;
+	uint32_t mc_generalized_carveout5_cfg0;
 
 	/* Specifies enable for CA training */
-	u_int32_t emc_ca_training_enable;
+	uint32_t emc_ca_training_enable;
 	/* Set if bit 6 select is greater than bit 7 select; uses aremc.spec packet SWIZZLE_BIT6_GT_BIT7 */
-	u_int32_t swizzle_rank_byte_encode;
+	uint32_t swizzle_rank_byte_encode;
 	/* Specifies enable and offset for patched boot rom write */
-	u_int32_t boot_rom_patch_control;
+	uint32_t boot_rom_patch_control;
 	/* Specifies data for patched boot rom write */
-	u_int32_t boot_rom_patch_data;
+	uint32_t boot_rom_patch_data;
 
 	/* Specifies the value for MC_MTS_CARVEOUT_BOM */
-	u_int32_t mc_mts_carveout_bom;
+	uint32_t mc_mts_carveout_bom;
 	/* Specifies the value for MC_MTS_CARVEOUT_ADR_HI */
-	u_int32_t mc_mts_carveout_adr_hi;
+	uint32_t mc_mts_carveout_adr_hi;
 	/* Specifies the value for MC_MTS_CARVEOUT_SIZE_MB */
-	u_int32_t mc_mts_carveout_size_mb;
+	uint32_t mc_mts_carveout_size_mb;
 	/* Specifies the value for MC_MTS_CARVEOUT_REG_CTRL */
-	u_int32_t mc_mts_carveout_reg_ctrl;
+	uint32_t mc_mts_carveout_reg_ctrl;
 	/* End of generated code by warmboot_code_gen */
 
 } nvboot_sdram_params;

--- a/src/t30/nvbctlib_t30.c
+++ b/src/t30/nvbctlib_t30.c
@@ -59,22 +59,22 @@ case token_bl_##x:\
 #define CASE_GET_NVU32(id) \
 case token_##id:\
 	if (bct == NULL) return -ENODATA; \
-	*((u_int32_t *)data) = bct_ptr->id; \
+	*((uint32_t *)data) = bct_ptr->id; \
 	break
 
 #define CASE_GET_CONST(id, val) \
 case token_##id:\
-	*((u_int32_t *)data) = val; \
+	*((uint32_t *)data) = val; \
 	break
 
 #define CASE_GET_CONST_PREFIX(id, val_prefix) \
 case token_##id:\
-	*((u_int32_t *)data) = val_prefix##_##id; \
+	*((uint32_t *)data) = val_prefix##_##id; \
 	break
 
 #define CASE_SET_NVU32(id) \
 case token_##id:\
-	bct_ptr->id = *((u_int32_t *)data); \
+	bct_ptr->id = *((uint32_t *)data); \
 	break
 
 #define CASE_GET_DATA(id, size) \
@@ -113,9 +113,9 @@ parse_token t30_root_token_list[] = {
 
 int
 t30_set_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t value)
+	uint32_t value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -164,9 +164,9 @@ t30_set_dev_param(build_image_context *context,
 
 int
 t30_get_dev_param(build_image_context *context,
-	u_int32_t index,
+	uint32_t index,
 	parse_token token,
-	u_int32_t *value)
+	uint32_t *value)
 {
 	nvboot_config_table *bct = NULL;
 
@@ -213,9 +213,9 @@ t30_get_dev_param(build_image_context *context,
 
 int
 t30_get_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t *value)
+		uint32_t *value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -427,9 +427,9 @@ t30_get_sdram_param(build_image_context *context,
 
 int
 t30_set_sdram_param(build_image_context *context,
-		u_int32_t index,
+		uint32_t index,
 		parse_token token,
-		u_int32_t value)
+		uint32_t value)
 {
 	nvboot_sdram_params *params;
 	nvboot_config_table *bct = NULL;
@@ -642,10 +642,10 @@ t30_set_sdram_param(build_image_context *context,
 }
 
 int
-t30_getbl_param(u_int32_t set,
+t30_getbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -677,10 +677,10 @@ t30_getbl_param(u_int32_t set,
 }
 
 int
-t30_setbl_param(u_int32_t set,
+t30_setbl_param(uint32_t set,
 		parse_token id,
-		u_int32_t *data,
-		u_int8_t *bct)
+		uint32_t *data,
+		uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -712,7 +712,7 @@ t30_setbl_param(u_int32_t set,
 }
 
 int
-t30_bct_get_value(parse_token id, void *data, u_int8_t *bct)
+t30_bct_get_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 	nvboot_config_table  samplebct; /* Used for computing offsets. */
@@ -740,13 +740,13 @@ t30_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	case token_block_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->block_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->block_size_log2;
 		break;
 
 	case token_page_size:
 		if (bct == NULL)
 			return -ENODATA;
-		*((u_int32_t *)data) = 1 << bct_ptr->page_size_log2;
+		*((uint32_t *)data) = 1 << bct_ptr->page_size_log2;
 		break;
 
 	/*
@@ -757,25 +757,25 @@ t30_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 	CASE_GET_CONST(reserved_size,     NVBOOT_BCT_RESERVED_SIZE);
 
 	case token_reserved_offset:
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.reserved)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.reserved)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_bct_size:
-		*((u_int32_t *)data) = sizeof(nvboot_config_table);
+		*((uint32_t *)data) = sizeof(nvboot_config_table);
 		break;
 
 	CASE_GET_CONST(hash_size, sizeof(nvboot_hash));
 
 	case token_crypto_offset:
 		/* Offset to region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = (u_int8_t *)&(samplebct.random_aes_blk)
-				- (u_int8_t *)&samplebct;
+		*((uint32_t *)data) = (uint8_t *)&(samplebct.random_aes_blk)
+				- (uint8_t *)&samplebct;
 		break;
 
 	case token_crypto_length:
 		/* size   of region in BCT to encrypt & sign */
-		*((u_int32_t *)data) = sizeof(nvboot_config_table) - sizeof(nvboot_hash);
+		*((uint32_t *)data) = sizeof(nvboot_config_table) - sizeof(nvboot_hash);
 	break;
 
 	CASE_GET_CONST(max_bct_search_blks, NVBOOT_MAX_BCT_SEARCH_BLOCKS);
@@ -803,7 +803,7 @@ t30_bct_get_value(parse_token id, void *data, u_int8_t *bct)
 }
 
 int
-t30_bct_set_value(parse_token id, void *data, u_int8_t *bct)
+t30_bct_set_value(parse_token id, void *data, uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -832,9 +832,9 @@ t30_bct_set_value(parse_token id, void *data, u_int8_t *bct)
 
 int
 t30_bct_set_data(parse_token id,
-	u_int8_t *data,
-	u_int32_t  length,
-	u_int8_t *bct)
+	uint8_t *data,
+	uint32_t  length,
+	uint8_t *bct)
 {
 	nvboot_config_table *bct_ptr = (nvboot_config_table *)bct;
 
@@ -870,7 +870,7 @@ int t30_bct_token_supported(parse_token token)
 
 void t30_init_bad_block_table(build_image_context *context)
 {
-	u_int32_t bytes_per_entry;
+	uint32_t bytes_per_entry;
 	nvboot_badblock_table *table;
 	nvboot_config_table *bct;
 

--- a/src/t30/nvboot_bct_t30.h
+++ b/src/t30/nvboot_bct_t30.h
@@ -97,7 +97,7 @@ enum {NVBOOT_CMAC_AES_HASH_LENGTH = 4};
  * Defines the storage for a hash value (128 bits).
  */
 typedef struct nvboot_hash_rec {
-	u_int32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
+	uint32_t hash[NVBOOT_CMAC_AES_HASH_LENGTH];
 } nvboot_hash;
 
 /**
@@ -109,63 +109,63 @@ typedef struct nvboot_nand_params_rec {
 	 * If it is set to 18, then clock source to Nand controller is
 	 * 432 / 18 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the value to be programmed to Nand Async Timing
 	 * Register 0
 	 */
-	u_int32_t async_timing0;
+	uint32_t async_timing0;
 	/**
 	 * Specifies the value to be programmed to Nand Async Timing
 	 * Register 1
 	 */
-	u_int32_t async_timing1;
+	uint32_t async_timing1;
 	/**
 	 * Specifies the value to be programmed to Nand Async Timing
 	 * Register 2
 	 */
-	u_int32_t async_timing2;
+	uint32_t async_timing2;
 	/**
 	 * Specifies the value to be programmed to Nand Async Timing
 	 * Register 3
 	 */
-	u_int32_t async_timing3;
+	uint32_t async_timing3;
 	/**
 	 * Specifies the value to be programmed to Nand Sync DDR Timing
 	 * Register 0
 	 */
-	u_int32_t sddr_timing0;
+	uint32_t sddr_timing0;
 	/**
 	 * Specifies the value to be programmed to Nand Sync DDR Timing
 	 * Register 1
 	 */
-	u_int32_t sddr_timing1;
+	uint32_t sddr_timing1;
 	/**
 	 * Specifies the value to be programmed to Nand Toggle DDR Timing
 	 * Register 0
 	 */
-	u_int32_t tddr_timing0;
+	uint32_t tddr_timing0;
 	/**
 	 * Specifies the value to be programmed to Nand Toggle DDR Timing
 	 * Register 1
 	 */
-	u_int32_t tddr_timing1;
+	uint32_t tddr_timing1;
 	/* Specifies the value to be programmed to FBIO_DQSIB_DELAY register */
-	u_int8_t fbio_dqsib_dly_byte;
+	uint8_t fbio_dqsib_dly_byte;
 	/* Specifies the value to be programmed to FBIO_DQUSE_DELAY register */
-	u_int8_t fbio_quse_dly_byte;
+	uint8_t fbio_quse_dly_byte;
 	/* Specifies the CFG_QUSE_LATE value to be programmed to FBIO
 	 * configuration register */
-	u_int8_t fbio_cfg_quse_late;
+	uint8_t fbio_cfg_quse_late;
 	/* Specifies whether to enable sync DDR more or not */
-	u_int8_t disable_sync_ddr;
+	uint8_t disable_sync_ddr;
 
 	/* Specifies the block size in log2 bytes */
-	u_int8_t block_size_log2;
+	uint8_t block_size_log2;
 
 	/* Specifies the page size in log2 bytes */
-	u_int8_t page_size_log2;
+	uint8_t page_size_log2;
 } nvboot_nand_params;
 
 /* Defines various data widths supported. */
@@ -212,7 +212,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * which is PLLP running at 432MHz.  If it is set to 18, then the SDMMC
 	 * controller runs at 432/18 = 24MHz.
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/* Specifies the data bus width. Supported data widths are 4/8 bits. */
 	nvboot_sdmmc_data_width data_width;
@@ -223,7 +223,7 @@ typedef struct nvboot_sdmmc_params_rec {
 	 * supported within the power class range (0 to Max) if the selected
 	 * data width cannot be used at the chosen clock frequency.
 	 */
-	u_int8_t max_power_class_supported;
+	uint8_t max_power_class_supported;
 
 	/* Specifies the SD controller to be selected */
 	nvboot_sdmmc_cntrl sd_controller;
@@ -266,21 +266,21 @@ typedef struct nvboot_spiflash_params_rec {
 	 *     FAST_READ   at 40MHz: 11
 	 *     FAST_READ   at 50MHz:  9
 	 */
-	u_int8_t clock_divider;
+	uint8_t clock_divider;
 
 	/**
 	 * Specifies the type of command for read operations.
 	 * NV_FALSE specifies a NORMAL_READ Command
 	 * NV_TRUE  specifies a FAST_READ   Command
 	 */
-	u_int8_t read_command_type_fast;
+	uint8_t read_command_type_fast;
 } nvboot_spiflash_params;
 
 /**
 * Defines the union of the parameters required by each device.
 */
 typedef union {
-	u_int8_t size[64];
+	uint8_t size[64];
 	/* Specifies optimized parameters for NAND */
 	nvboot_nand_params nand_params;
 	/* Specifies optimized parameters for eMMC and eSD */
@@ -321,13 +321,13 @@ typedef enum {
  * the device.
  */
 typedef struct nv_bootloader_info_rec {
-	u_int32_t version;
-	u_int32_t start_blk;
-	u_int32_t start_page;
-	u_int32_t length;
-	u_int32_t load_addr;
-	u_int32_t entry_point;
-	u_int32_t attribute;
+	uint32_t version;
+	uint32_t start_blk;
+	uint32_t start_page;
+	uint32_t length;
+	uint32_t load_addr;
+	uint32_t entry_point;
+	uint32_t attribute;
 	nvboot_hash crypto_hash;
 } nv_bootloader_info;
 
@@ -335,10 +335,10 @@ typedef struct nv_bootloader_info_rec {
  * Defines the bad block table structure stored in the BCT.
  */
 typedef struct nvboot_badblock_table_rec {
-	u_int32_t entries_used;
-	u_int8_t virtual_blk_size_log2;
-	u_int8_t block_size_log2;
-	u_int8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
+	uint32_t entries_used;
+	uint8_t virtual_blk_size_log2;
+	uint8_t block_size_log2;
+	uint8_t bad_blks[NVBOOT_BAD_BLOCK_TABLE_SIZE / 8];
 } nvboot_badblock_table;
 
 /**
@@ -352,28 +352,28 @@ typedef struct nvboot_badblock_table_rec {
 typedef struct nvboot_config_table_rec {
 	nvboot_hash crypto_hash;
 	nvboot_hash random_aes_blk;
-	u_int32_t boot_data_version;
-	u_int32_t block_size_log2;
-	u_int32_t page_size_log2;
-	u_int32_t partition_size;
-	u_int32_t num_param_sets;
+	uint32_t boot_data_version;
+	uint32_t block_size_log2;
+	uint32_t page_size_log2;
+	uint32_t partition_size;
+	uint32_t num_param_sets;
 	nvboot_dev_type dev_type[NVBOOT_BCT_MAX_PARAM_SETS];
 	nvboot_dev_params dev_params[NVBOOT_BCT_MAX_PARAM_SETS];
-	u_int32_t num_sdram_sets;
+	uint32_t num_sdram_sets;
 	nvboot_sdram_params sdram_params[NVBOOT_BCT_MAX_SDRAM_SETS];
 	nvboot_badblock_table badblock_table;
-	u_int32_t bootloader_used;
+	uint32_t bootloader_used;
 	nv_bootloader_info bootloader[NVBOOT_MAX_BOOTLOADERS];
-	u_int8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
+	uint8_t customer_data[NVBOOT_BCT_CUSTOMER_DATA_SIZE];
 	/*
 	 * ODMDATA is stored in the BCT in IRAM by the BootROM.
 	 * Read the data @ bct_start + (bct_size - 12). This works
 	 * on T20 and T30 BCTs, which are locked down. If this changes
 	 * in new chips, we can revisit this algorithm.
 	 */
-	u_int32_t odm_data;
-	u_int32_t reserved1;
-	u_int8_t enable_fail_back;
-	u_int8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
+	uint32_t odm_data;
+	uint32_t reserved1;
+	uint8_t enable_fail_back;
+	uint8_t reserved[NVBOOT_BCT_RESERVED_SIZE];
 } nvboot_config_table;
 #endif /* #ifndef INCLUDED_NVBOOT_BCT_T30_H */

--- a/src/t30/nvboot_sdram_param_t30.h
+++ b/src/t30/nvboot_sdram_param_t30.h
@@ -63,299 +63,299 @@ typedef struct nvboot_sdram_params_rec {
 	/* MC/EMC clock source configuration */
 
 	/* Specifies the CPCON value for PllM */
-	u_int32_t pllm_charge_pump_setup_ctrl;
+	uint32_t pllm_charge_pump_setup_ctrl;
 	/* Specifies the LPCON value for PllM */
-	u_int32_t pllm_loop_filter_setup_ctrl;
+	uint32_t pllm_loop_filter_setup_ctrl;
 	/* Specifies the M value for PllM */
-	u_int32_t pllm_input_divider;
+	uint32_t pllm_input_divider;
 	/* Specifies the N value for PllM */
-	u_int32_t pllm_feedback_divider;
+	uint32_t pllm_feedback_divider;
 	/* Specifies the P value for PllM */
-	u_int32_t pllm_post_divider;
+	uint32_t pllm_post_divider;
 	/* Specifies the time to wait for PLLM to lock (in microseconds) */
-	u_int32_t pllm_stable_time;
+	uint32_t pllm_stable_time;
 
 	/* Specifies the divider for the EMC Clock Source */
-	u_int32_t emc_clock_divider;
+	uint32_t emc_clock_divider;
 	/* Specifies the PLL source for the EMC Clock Source */
-	u_int32_t emc_clock_source;
+	uint32_t emc_clock_source;
 	/*
 	 * Specifies the enable for using low jitter clock for
 	 * the EMC Clock Source
 	 */
-	u_int32_t emc_clock_use_pll_mud;
+	uint32_t emc_clock_use_pll_mud;
 
 	/* Auto-calibration of EMC pads */
 
 	/* Specifies the value for EMC_AUTO_CAL_INTERVAL */
-	u_int32_t emc_auto_cal_interval;
+	uint32_t emc_auto_cal_interval;
 	/*
 	 * Specifies the value for EMC_AUTO_CAL_CONFIG
 	 * Note: Trigger bits are set by the SDRAM code.
 	 */
-	u_int32_t emc_auto_cal_config;
+	uint32_t emc_auto_cal_config;
 	/*
 	 * Specifies the time for the calibration
 	 * to stabilize (in microseconds)
 	 */
-	u_int32_t emc_auto_cal_wait;
+	uint32_t emc_auto_cal_wait;
 
 	/*
 	 * DRAM size information
 	 * Specifies the value for EMC_ADR_CFG
 	 */
-	u_int32_t emc_adr_cfg;
+	uint32_t emc_adr_cfg;
 
 	/*
 	 * Specifies the time to wait after asserting pin
 	 * CKE (in microseconds)
 	 */
-	u_int32_t emc_pin_program_wait;
+	uint32_t emc_pin_program_wait;
 	/* Specifies the extra delay before/after pin RESET/CKE command */
-	u_int32_t emc_pin_extra_wait;
+	uint32_t emc_pin_extra_wait;
 	/*
 	 * Specifies the extra delay after the first writing
 	 * of EMC_TIMING_CONTROL
 	 */
-	u_int32_t emc_timing_control_wait;
+	uint32_t emc_timing_control_wait;
 
 	/* Timing parameters required for the SDRAM */
 
 	/* Specifies the value for EMC_RC */
-	u_int32_t emc_rc;
+	uint32_t emc_rc;
 	/* Specifies the value for EMC_RFC */
-	u_int32_t emc_rfc;
+	uint32_t emc_rfc;
 	/* Specifies the value for EMC_RAS */
-	u_int32_t emc_ras;
+	uint32_t emc_ras;
 	/* Specifies the value for EMC_RP */
-	u_int32_t emc_rp;
+	uint32_t emc_rp;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_r2w;
+	uint32_t emc_r2w;
 	/* Specifies the value for EMC_R2W */
-	u_int32_t emc_w2r;
+	uint32_t emc_w2r;
 	/* Specifies the value for EMC_R2P */
-	u_int32_t emc_r2p;
+	uint32_t emc_r2p;
 	/* Specifies the value for EMC_W2P */
-	u_int32_t emc_w2p;
+	uint32_t emc_w2p;
 	/* Specifies the value for EMC_RD_RCD */
-	u_int32_t emc_rd_rcd;
+	uint32_t emc_rd_rcd;
 	/* Specifies the value for EMC_WR_RCD */
-	u_int32_t emc_wr_rcd;
+	uint32_t emc_wr_rcd;
 	/* Specifies the value for EMC_RRD */
-	u_int32_t emc_rrd;
+	uint32_t emc_rrd;
 	/* Specifies the value for EMC_REXT */
-	u_int32_t emc_rext;
+	uint32_t emc_rext;
 	/* Specifies the value for EMC_WEXT */
-	u_int32_t emc_wext;
+	uint32_t emc_wext;
 	/* Specifies the value for EMC_WDV */
-	u_int32_t emc_wdv;
+	uint32_t emc_wdv;
 	/* Specifies the value for EMC_QUSE */
-	u_int32_t emc_quse;
+	uint32_t emc_quse;
 	/* Specifies the value for EMC_QRST */
-	u_int32_t emc_qrst;
+	uint32_t emc_qrst;
 	/* Specifies the value for EMC_QSAFE */
-	u_int32_t emc_qsafe;
+	uint32_t emc_qsafe;
 	/* Specifies the value for EMC_RDV */
-	u_int32_t emc_rdv;
+	uint32_t emc_rdv;
 	/* Specifies the value for EMC_CTT */
-	u_int32_t emc_ctt;
+	uint32_t emc_ctt;
 	/* Specifies the value for EMC_CTT_DURATION */
-	u_int32_t emc_ctt_duration;
+	uint32_t emc_ctt_duration;
 	/* Specifies the value for EMC_REFRESH */
-	u_int32_t emc_refresh;
+	uint32_t emc_refresh;
 	/* Specifies the value for EMC_BURST_REFRESH_NUM */
-	u_int32_t emc_burst_refresh_num;
+	uint32_t emc_burst_refresh_num;
 	/* Specifies the value for EMC_PRE_REFRESH_REQ_CNT */
-	u_int32_t emc_prerefresh_req_cnt;
+	uint32_t emc_prerefresh_req_cnt;
 	/* Specifies the value for EMC_PDEX2WR */
-	u_int32_t emc_pdex2wr;
+	uint32_t emc_pdex2wr;
 	/* Specifies the value for EMC_PDEX2RD */
-	u_int32_t emc_pdex2rd;
+	uint32_t emc_pdex2rd;
 	/* Specifies the value for EMC_PCHG2PDEN */
-	u_int32_t emc_pchg2pden;
+	uint32_t emc_pchg2pden;
 	/* Specifies the value for EMC_ACT2PDEN */
-	u_int32_t emc_act2pden;
+	uint32_t emc_act2pden;
 	/* Specifies the value for EMC_AR2PDEN */
-	u_int32_t emc_ar2pden;
+	uint32_t emc_ar2pden;
 	/* Specifies the value for EMC_RW2PDEN */
-	u_int32_t emc_rw2pden;
+	uint32_t emc_rw2pden;
 	/* Specifies the value for EMC_TXSR */
-	u_int32_t emc_txsr;
+	uint32_t emc_txsr;
 	/* Specifies the value for EMC_TXSRDLL */
-	u_int32_t emc_txsr_dll;
+	uint32_t emc_txsr_dll;
 	/* Specifies the value for EMC_TCKE */
-	u_int32_t emc_tcke;
+	uint32_t emc_tcke;
 	/* Specifies the value for EMC_TFAW */
-	u_int32_t emc_tfaw;
+	uint32_t emc_tfaw;
 	/* Specifies the value for EMC_TRPAB */
-	u_int32_t emc_trpab;
+	uint32_t emc_trpab;
 	/* Specifies the value for EMC_TCLKSTABLE */
-	u_int32_t emc_tclkstable;
+	uint32_t emc_tclkstable;
 	/* Specifies the value for EMC_TCLKSTOP */
-	u_int32_t emc_tclkstop;
+	uint32_t emc_tclkstop;
 	/* Specifies the value for EMC_TREFBW */
-	u_int32_t emc_trefbw;
+	uint32_t emc_trefbw;
 	/* Specifies the value for EMC_QUSE_EXTRA */
-	u_int32_t emc_quse_extra;
+	uint32_t emc_quse_extra;
 
 	/* FBIO configuration values */
 
 	/* Specifies the value for EMC_FBIO_CFG5 */
-	u_int32_t emc_fbio_cfg5;
+	uint32_t emc_fbio_cfg5;
 	/* Specifies the value for EMC_FBIO_CFG6 */
-	u_int32_t emc_fbio_cfg6;
+	uint32_t emc_fbio_cfg6;
 	/* Specifies the value for EMC_FBIO_SPARE */
-	u_int32_t emc_fbio_spare;
+	uint32_t emc_fbio_spare;
 
 	/* Specifies the value for EMC_CFG_RSV */
-	u_int32_t emc_cfg_rsv;
+	uint32_t emc_cfg_rsv;
 
 	/* MRS command values */
 
 	/* Specifies the value for EMC_MRS */
-	u_int32_t emc_mrs;
+	uint32_t emc_mrs;
 	/* Specifies the value for EMC_EMRS */
-	u_int32_t emc_emrs;
+	uint32_t emc_emrs;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at cold boot */
-	u_int32_t emc_mrw1;
+	uint32_t emc_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at cold boot */
-	u_int32_t emc_mrw2;
+	uint32_t emc_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at cold boot */
-	u_int32_t emc_mrw3;
+	uint32_t emc_mrw3;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at cold boot
 	 */
-	u_int32_t emc_mrw_extra;
+	uint32_t emc_mrw_extra;
 	/* Specifies the programming to LPDDR2 Mode Register 1 at warm boot */
-	u_int32_t emc_warm_boot_mrw1;
+	uint32_t emc_warm_boot_mrw1;
 	/* Specifies the programming to LPDDR2 Mode Register 2 at warm boot */
-	u_int32_t emc_warm_boot_mrw2;
+	uint32_t emc_warm_boot_mrw2;
 	/* Specifies the programming to LPDDR2 Mode Register 3 at warm boot */
-	u_int32_t emc_warm_boot_mrw3;
+	uint32_t emc_warm_boot_mrw3;
 	/*
 	 * Specifies the programming to extra LPDDR2 Mode Register
 	 * at warm boot
 	 */
-	u_int32_t emc_warm_boot_mrw_extra;
+	uint32_t emc_warm_boot_mrw_extra;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * warm boot
 	 */
-	u_int32_t emc_warm_boot_extramode_reg_write_enable;
+	uint32_t emc_warm_boot_extramode_reg_write_enable;
 	/*
 	 * Specify the enable of extra Mode Register programming at
 	 * cold boot
 	 */
-	u_int32_t emc_extramode_reg_write_enable;
+	uint32_t emc_extramode_reg_write_enable;
 
 	/* Specifies the EMC_MRW reset command value */
-	u_int32_t emc_mrw_reset_command;
+	uint32_t emc_mrw_reset_command;
 	/* Specifies the EMC Reset wait time (in microseconds) */
-	u_int32_t emc_mrw_reset_ninit_wait;
+	uint32_t emc_mrw_reset_ninit_wait;
 	/* Specifies the value for EMC_MRS_WAIT_CNT */
-	u_int32_t emc_mrs_wait_cnt;
+	uint32_t emc_mrs_wait_cnt;
 
 	/* EMC miscellaneous configurations */
 
 	/* Specifies the value for EMC_CFG */
-	u_int32_t emc_cfg;
+	uint32_t emc_cfg;
 	/* Specifies the value for EMC_CFG_2 */
-	u_int32_t emc_cfg2;
+	uint32_t emc_cfg2;
 	/* Specifies the value for EMC_DBG */
-	u_int32_t emc_dbg;
+	uint32_t emc_dbg;
 	/* Specifies the value for EMC_CMDQ */
-	u_int32_t emc_cmd_q;
+	uint32_t emc_cmd_q;
 	/* Specifies the value for EMC_MC2EMCQ */
-	u_int32_t emc_mc2emc_q;
+	uint32_t emc_mc2emc_q;
 	/* Specifies the value for EMC_DYN_SELF_REF_CONTROL */
-	u_int32_t emc_dyn_self_ref_control;
+	uint32_t emc_dyn_self_ref_control;
 
 	/* Specifies the value for MEM_INIT_DONE */
-	u_int32_t ahb_arbitration_xbar_ctrl_meminit_done;
+	uint32_t ahb_arbitration_xbar_ctrl_meminit_done;
 
 	/* Specifies the value for EMC_CFG_DIG_DLL */
-	u_int32_t emc_cfg_dig_dll;
+	uint32_t emc_cfg_dig_dll;
 	/* Specifies the value for EMC_CFG_DIG_DLL_PERIOD */
-	u_int32_t emc_cfg_dig_dll_period;
+	uint32_t emc_cfg_dig_dll_period;
 	/* Specifies the vlaue of *DEV_SELECTN of various EMC registers */
-	u_int32_t emc_dev_select;
+	uint32_t emc_dev_select;
 
 	/* Specifies the value for EMC_SEL_DPD_CTRL */
-	u_int32_t emc_sel_dpd_ctrl;
+	uint32_t emc_sel_dpd_ctrl;
 
 	/* Pads trimmer delays */
 
 	/* Specifies the value for EMC_DLL_XFORM_DQS0 */
-	u_int32_t emc_dll_xform_dqs0;
+	uint32_t emc_dll_xform_dqs0;
 	/* Specifies the value for EMC_DLL_XFORM_DQS1 */
-	u_int32_t emc_dll_xform_dqs1;
+	uint32_t emc_dll_xform_dqs1;
 	/* Specifies the value for EMC_DLL_XFORM_DQS2 */
-	u_int32_t emc_dll_xform_dqs2;
+	uint32_t emc_dll_xform_dqs2;
 	/* Specifies the value for EMC_DLL_XFORM_DQS3 */
-	u_int32_t emc_dll_xform_dqs3;
+	uint32_t emc_dll_xform_dqs3;
 	/* Specifies the value for EMC_DLL_XFORM_DQS4 */
-	u_int32_t emc_dll_xform_dqs4;
+	uint32_t emc_dll_xform_dqs4;
 	/* Specifies the value for EMC_DLL_XFORM_DQS5 */
-	u_int32_t emc_dll_xform_dqs5;
+	uint32_t emc_dll_xform_dqs5;
 	/* Specifies the value for EMC_DLL_XFORM_DQS6 */
-	u_int32_t emc_dll_xform_dqs6;
+	uint32_t emc_dll_xform_dqs6;
 	/* Specifies the value for EMC_DLL_XFORM_DQS7 */
-	u_int32_t emc_dll_xform_dqs7;
+	uint32_t emc_dll_xform_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE0 */
-	u_int32_t emc_dll_xform_quse0;
+	uint32_t emc_dll_xform_quse0;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE1 */
-	u_int32_t emc_dll_xform_quse1;
+	uint32_t emc_dll_xform_quse1;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE2 */
-	u_int32_t emc_dll_xform_quse2;
+	uint32_t emc_dll_xform_quse2;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE3 */
-	u_int32_t emc_dll_xform_quse3;
+	uint32_t emc_dll_xform_quse3;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE4 */
-	u_int32_t emc_dll_xform_quse4;
+	uint32_t emc_dll_xform_quse4;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE5 */
-	u_int32_t emc_dll_xform_quse5;
+	uint32_t emc_dll_xform_quse5;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE6 */
-	u_int32_t emc_dll_xform_quse6;
+	uint32_t emc_dll_xform_quse6;
 	/* Specifies the value for EMC_DLL_XFORM_QUSE7 */
-	u_int32_t emc_dll_xform_quse7;
+	uint32_t emc_dll_xform_quse7;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS0 */
-	u_int32_t emc_dli_trim_tx_dqs0;
+	uint32_t emc_dli_trim_tx_dqs0;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS1 */
-	u_int32_t emc_dli_trim_tx_dqs1;
+	uint32_t emc_dli_trim_tx_dqs1;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS2 */
-	u_int32_t emc_dli_trim_tx_dqs2;
+	uint32_t emc_dli_trim_tx_dqs2;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS3 */
-	u_int32_t emc_dli_trim_tx_dqs3;
+	uint32_t emc_dli_trim_tx_dqs3;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS4 */
-	u_int32_t emc_dli_trim_tx_dqs4;
+	uint32_t emc_dli_trim_tx_dqs4;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS5 */
-	u_int32_t emc_dli_trim_tx_dqs5;
+	uint32_t emc_dli_trim_tx_dqs5;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS6 */
-	u_int32_t emc_dli_trim_tx_dqs6;
+	uint32_t emc_dli_trim_tx_dqs6;
 	/* Specifies the value for EMC_DLI_TRIM_TXDQS7 */
-	u_int32_t emc_dli_trim_tx_dqs7;
+	uint32_t emc_dli_trim_tx_dqs7;
 	/* Specifies the value for EMC_DLL_XFORM_DQ0 */
-	u_int32_t emc_dll_xform_dq0;
+	uint32_t emc_dll_xform_dq0;
 	/* Specifies the value for EMC_DLL_XFORM_DQ1 */
-	u_int32_t emc_dll_xform_dq1;
+	uint32_t emc_dll_xform_dq1;
 	/* Specifies the value for EMC_DLL_XFORM_DQ2 */
-	u_int32_t emc_dll_xform_dq2;
+	uint32_t emc_dll_xform_dq2;
 	/* Specifies the value for EMC_DLL_XFORM_DQ3 */
-	u_int32_t emc_dll_xform_dq3;
+	uint32_t emc_dll_xform_dq3;
 
 	/*
 	 * Specifies the delay after asserting CKE pin during a WarmBoot0
 	 * sequence (in microseconds)
 	 */
-	u_int32_t warm_boot_wait;
+	uint32_t warm_boot_wait;
 
 	/* Specifies the value for EMC_CTT_TERM_CTRL */
-	u_int32_t emc_ctt_term_ctrl;
+	uint32_t emc_ctt_term_ctrl;
 
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_write;
+	uint32_t emc_odt_write;
 	/* Specifies the value for EMC_ODT_WRITE */
-	u_int32_t emc_odt_read;
+	uint32_t emc_odt_read;
 
 	/* Periodic ZQ calibration */
 
@@ -363,204 +363,204 @@ typedef struct nvboot_sdram_params_rec {
 	 * Specifies the value for EMC_ZCAL_INTERVAL
 	 * Value 0 disables ZQ calibration
 	 */
-	u_int32_t emc_zcal_interval;
+	uint32_t emc_zcal_interval;
 	/* Specifies the value for EMC_ZCAL_WAIT_CNT */
-	u_int32_t emc_zcal_wait_cnt;
+	uint32_t emc_zcal_wait_cnt;
 	/* Specifies the value for EMC_ZCAL_MRW_CMD */
-	u_int32_t emc_zcal_mrw_cmd;
+	uint32_t emc_zcal_mrw_cmd;
 
 	/* DRAM initialization sequence flow control */
 
 	/* Specifies the MRS command value for resetting DLL */
-	u_int32_t emc_mrs_reset_dll;
+	uint32_t emc_mrs_reset_dll;
 	/* Specifies the command for ZQ initialization of device 0 */
-	u_int32_t emc_zcal_init_dev0;
+	uint32_t emc_zcal_init_dev0;
 	/* Specifies the command for ZQ initialization of device 1 */
-	u_int32_t emc_zcal_init_dev1;
+	uint32_t emc_zcal_init_dev1;
 	/*
 	 * Specifies the wait time after programming a ZQ initialization
 	 * command (in microseconds)
 	 */
-	u_int32_t emc_zcal_init_wait;
+	uint32_t emc_zcal_init_wait;
 	/* Specifies the enable for ZQ calibration at cold boot */
-	u_int32_t emc_zcal_cold_boot_enable;
+	uint32_t emc_zcal_cold_boot_enable;
 	/* Specifies the enable for ZQ calibration at warm boot */
-	u_int32_t emc_zcal_warm_boot_enable;
+	uint32_t emc_zcal_warm_boot_enable;
 
 	/*
 	 * Specifies the MRW command to LPDDR2 for ZQ calibration
 	 *on warmboot
 	 */
 	/* Is issued to both devices separately */
-	u_int32_t emc_mrw_lpddr2zcal_warm_boot;
+	uint32_t emc_mrw_lpddr2zcal_warm_boot;
 	/*
 	 * Specifies the ZQ command to DDR3 for ZQ calibration on warmboot
 	 * Is issued to both devices separately
 	 */
-	u_int32_t emc_zqcal_ddr3_warm_boot;
+	uint32_t emc_zqcal_ddr3_warm_boot;
 	/*
 	 * Specifies the wait time for ZQ calibration on warmboot
 	 * (in microseconds)
 	 */
-	u_int32_t emc_zcal_warm_boot_wait;
+	uint32_t emc_zcal_warm_boot_wait;
 	/*
 	 * Specifies the enable for DRAM Mode Register programming
 	 * at warm boot
 	 */
-	u_int32_t emc_mrs_warm_boot_enable;
+	uint32_t emc_mrs_warm_boot_enable;
 	/*
 	 * Specifies the wait time after sending an MRS DLL reset command
 	 * in microseconds)
 	 */
-	u_int32_t emc_mrs_reset_dll_wait;
+	uint32_t emc_mrs_reset_dll_wait;
 	/*
 	 * Specifies the first of two EMRS commands to initialize mode
 	 * registers
 	 */
-	u_int32_t emc_emrs_emr2;
+	uint32_t emc_emrs_emr2;
 	/*
 	 * Specifies the second of two EMRS commands to initialize mode
 	 * registers
 	 */
-	u_int32_t emc_emrs_emr3;
+	uint32_t emc_emrs_emr3;
 	/* Specifies the extra MRS command to initialize mode registers */
-	u_int32_t emc_mrs_extra;
+	uint32_t emc_mrs_extra;
 	/* Specifies the programming to DDR3 Mode Register 0 at warm boot */
-	u_int32_t emc_warm_boot_mrs;
+	uint32_t emc_warm_boot_mrs;
 	/* Specifies the programming to DDR3 Mode Register 1 at warm boot */
-	u_int32_t emc_warm_boot_emrs;
+	uint32_t emc_warm_boot_emrs;
 	/* Specifies the programming to DDR3 Mode Register 2 at warm boot */
-	u_int32_t emc_warm_boot_emr2;
+	uint32_t emc_warm_boot_emr2;
 	/* Specifies the programming to DDR3 Mode Register 3 at warm boot */
-	u_int32_t emc_warm_boot_emr3;
+	uint32_t emc_warm_boot_emr3;
 	/* Specifies the extra MRS command at warm boot */
-	u_int32_t emc_warm_boot_mrs_extra;
+	uint32_t emc_warm_boot_mrs_extra;
 	/* Specifies the EMRS command to enable the DDR2 DLL */
-	u_int32_t emc_emrs_ddr2_dll_enable;
+	uint32_t emc_emrs_ddr2_dll_enable;
 	/* Specifies the MRS command to reset the DDR2 DLL */
-	u_int32_t emc_mrs_ddr2_dll_reset;
+	uint32_t emc_mrs_ddr2_dll_reset;
 	/* Specifies the EMRS command to set OCD calibration */
-	u_int32_t emc_emrs_ddr2_ocd_calib;
+	uint32_t emc_emrs_ddr2_ocd_calib;
 	/*
 	 * Specifies the wait between initializing DDR and setting OCD
 	 * calibration (in microseconds)
 	 */
-	u_int32_t emc_ddr2_wait;
+	uint32_t emc_ddr2_wait;
 	/* Specifies the value for EMC_CLKEN_OVERRIDE */
-	u_int32_t emc_clken_override;
+	uint32_t emc_clken_override;
 	/*
 	 * Specifies LOG2 of the extra refresh numbers after booting
 	 * Program 0 to disable
 	 */
-	u_int32_t emc_extra_refresh_num;
+	uint32_t emc_extra_refresh_num;
 	/* Specifies the master override for all EMC clocks */
-	u_int32_t emc_clken_override_allwarm_boot;
+	uint32_t emc_clken_override_allwarm_boot;
 	/* Specifies the master override for all MC clocks */
-	u_int32_t mc_clken_override_allwarm_boot;
+	uint32_t mc_clken_override_allwarm_boot;
 	/* Specifies digital dll period, choosing between 4 to 64 ms */
-	u_int32_t emc_cfg_dig_dll_period_warm_boot;
+	uint32_t emc_cfg_dig_dll_period_warm_boot;
 
 	/* Pad controls */
 
 	/* Specifies the value for PMC_VDDP_SEL */
-	u_int32_t pmc_vddp_sel;
+	uint32_t pmc_vddp_sel;
 	/* Specifies the value for PMC_DDR_PWR */
-	u_int32_t pmc_ddr_pwr;
+	uint32_t pmc_ddr_pwr;
 	/* Specifies the value for PMC_DDR_CFG */
-	u_int32_t pmc_ddr_cfg;
+	uint32_t pmc_ddr_cfg;
 	/* Specifies the value for PMC_IO_DPD_REQ */
-	u_int32_t pmc_io_dpd_req;
+	uint32_t pmc_io_dpd_req;
 	/* Specifies the value for PMC_E_NO_VTTGEN */
-	u_int32_t pmc_eno_vtt_gen;
+	uint32_t pmc_eno_vtt_gen;
 	/* Specifies the value for PMC_NO_IOPOWER */
-	u_int32_t pmc_no_io_power;
+	uint32_t pmc_no_io_power;
 	/* Specifies the value for EMC_XM2CMDPADCTRL */
-	u_int32_t emc_xm2cmd_pad_ctrl;
+	uint32_t emc_xm2cmd_pad_ctrl;
 	/* Specifies the value for EMC_XM2CMDPADCTRL2 */
-	u_int32_t emc_xm2cmd_pad_ctrl2;
+	uint32_t emc_xm2cmd_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQSPADCTRL */
-	u_int32_t emc_xm2dqs_pad_ctrl;
+	uint32_t emc_xm2dqs_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQSPADCTRL2 */
-	u_int32_t emc_xm2dqs_pad_ctrl2;
+	uint32_t emc_xm2dqs_pad_ctrl2;
 	/* Specifies the value for EMC_XM2DQSPADCTRL3 */
-	u_int32_t emc_xm2dqs_pad_ctrl3;
+	uint32_t emc_xm2dqs_pad_ctrl3;
 	/* Specifies the value for EMC_XM2DQPADCTRL */
-	u_int32_t emc_xm2dq_pad_ctrl;
+	uint32_t emc_xm2dq_pad_ctrl;
 	/* Specifies the value for EMC_XM2DQPADCTRL2 */
-	u_int32_t emc_xm2dq_pad_ctrl2;
+	uint32_t emc_xm2dq_pad_ctrl2;
 	/* Specifies the value for EMC_XM2CLKPADCTRL */
-	u_int32_t emc_xm2clk_pad_ctrl;
+	uint32_t emc_xm2clk_pad_ctrl;
 	/* Specifies the value for EMC_XM2COMPPADCTRL */
-	u_int32_t emc_xm2comp_pad_ctrl;
+	uint32_t emc_xm2comp_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL */
-	u_int32_t emc_xm2vttgen_pad_ctrl;
+	uint32_t emc_xm2vttgen_pad_ctrl;
 	/* Specifies the value for EMC_XM2VTTGENPADCTRL2 */
-	u_int32_t emc_xm2vttgen_pad_ctrl2;
+	uint32_t emc_xm2vttgen_pad_ctrl2;
 	/* Specifies the value for EMC_XM2QUSEPADCTRL */
-	u_int32_t emc_xm2quse_pad_ctrl;
+	uint32_t emc_xm2quse_pad_ctrl;
 
 	/* DRAM size information */
 
 	/* Specifies the value for MC_EMEM_ADR_CFG */
-	u_int32_t mc_emem_adr_cfg;
+	uint32_t mc_emem_adr_cfg;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV0 */
-	u_int32_t mc_emem_adr_cfg_dev0;
+	uint32_t mc_emem_adr_cfg_dev0;
 	/* Specifies the value for MC_EMEM_ADR_CFG_DEV1 */
-	u_int32_t mc_emem_adr_cfg_dev1;
+	uint32_t mc_emem_adr_cfg_dev1;
 
 	/*
 	 * Specifies the value for MC_EMEM_CFG which holds the external memory
 	 * size (in KBytes)
 	 */
-	u_int32_t mc_emem_cfg;
+	uint32_t mc_emem_cfg;
 
 	/* MC arbitration configuration */
 
 	/* Specifies the value for MC_EMEM_ARB_CFG */
-	u_int32_t mc_emem_arb_cfg;
+	uint32_t mc_emem_arb_cfg;
 	/* Specifies the value for MC_EMEM_ARB_OUTSTANDING_REQ */
-	u_int32_t mc_emem_arb_outstanding_req;
+	uint32_t mc_emem_arb_outstanding_req;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RCD */
-	u_int32_t mc_emem_arb_timing_rcd;
+	uint32_t mc_emem_arb_timing_rcd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RP */
-	u_int32_t mc_emem_arb_timing_rp;
+	uint32_t mc_emem_arb_timing_rp;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RC */
-	u_int32_t mc_emem_arb_timing_rc;
+	uint32_t mc_emem_arb_timing_rc;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAS */
-	u_int32_t mc_emem_arb_timing_ras;
+	uint32_t mc_emem_arb_timing_ras;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_FAW */
-	u_int32_t mc_emem_arb_timing_faw;
+	uint32_t mc_emem_arb_timing_faw;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RRD */
-	u_int32_t mc_emem_arb_timing_rrd;
+	uint32_t mc_emem_arb_timing_rrd;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_RAP2PRE */
-	u_int32_t mc_emem_arb_timing_rap2pre;
+	uint32_t mc_emem_arb_timing_rap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_WAP2PRE */
-	u_int32_t mc_emem_arb_timing_wap2pre;
+	uint32_t mc_emem_arb_timing_wap2pre;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2R */
-	u_int32_t mc_emem_arb_timing_r2r;
+	uint32_t mc_emem_arb_timing_r2r;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2W */
-	u_int32_t mc_emem_arb_timing_w2w;
+	uint32_t mc_emem_arb_timing_w2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_R2W */
-	u_int32_t mc_emem_arb_timing_r2w;
+	uint32_t mc_emem_arb_timing_r2w;
 	/* Specifies the value for MC_EMEM_ARB_TIMING_W2R */
-	u_int32_t mc_emem_arb_timing_w2r;
+	uint32_t mc_emem_arb_timing_w2r;
 	/* Specifies the value for MC_EMEM_ARB_DA_TURNS */
-	u_int32_t mc_emem_arb_da_turns;
+	uint32_t mc_emem_arb_da_turns;
 	/* Specifies the value for MC_EMEM_ARB_DA_COVERS */
-	u_int32_t mc_emem_arb_da_covers;
+	uint32_t mc_emem_arb_da_covers;
 	/* Specifies the value for MC_EMEM_ARB_MISC0 */
-	u_int32_t mc_emem_arb_misc0;
+	uint32_t mc_emem_arb_misc0;
 	/* Specifies the value for MC_EMEM_ARB_MISC1 */
-	u_int32_t mc_emem_arb_misc1;
+	uint32_t mc_emem_arb_misc1;
 	/* Specifies the value for MC_EMEM_ARB_RING1_THROTTLE */
-	u_int32_t mc_emem_arb_ring1_throttle;
+	uint32_t mc_emem_arb_ring1_throttle;
 	/* Specifies the value for MC_EMEM_ARB_OVERRIDE */
-	u_int32_t mc_emem_arb_override;
+	uint32_t mc_emem_arb_override;
 	/* Specifies the value for MC_EMEM_ARB_RSV */
-	u_int32_t mc_emem_arb_rsv;
+	uint32_t mc_emem_arb_rsv;
 
 	/* Specifies the value for MC_CLKEN_OVERRIDE */
-	u_int32_t mc_clken_override;
+	uint32_t mc_clken_override;
 
 	/* End of generated code by warmboot_code_gen */
 } nvboot_sdram_params;


### PR DESCRIPTION
The u_intXX_t types are implementation-specific and not part of a
standard. As an example, they are not provided by the musl C library.

Therefore, this commit switches cbootimage to use the C99 uintXX_t
types. This commit has been produced by:

 1. Running:

    find . -name '*.[ch]' | xargs sed -i 's%u_int\([0-9]*\)_t%uint\1_t%g'

 2. Adding a #include <stdint.h> in cbootimage.h

The result has been compile tested with the musl C library.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>